### PR TITLE
fix: ignore createdAt when detecting duplicates

### DIFF
--- a/sveltekit/src/lib/helpers/import.ts
+++ b/sveltekit/src/lib/helpers/import.ts
@@ -89,8 +89,6 @@ export interface ImportSync {
 }
 
 export const importFromCanutinFile = async (canutinFile: CanutinFile) => {
-	const importSessionDate = new Date();
-
 	const importedAccounts: ImportedAccounts = {
 		created: [],
 		updated: [],
@@ -164,7 +162,6 @@ export const importFromCanutinFile = async (canutinFile: CanutinFile) => {
 				if (account.transactions) {
 					for (const transaction of account.transactions) {
 						const transactionImportBlueprint = {
-							createdAt: fromUnixTime(transaction.createdAt),
 							description: transaction.description,
 							date: fromUnixTime(transaction.date),
 							value: transaction.value,


### PR DESCRIPTION
- `createdAt` will likely be different every time a _scraper_ runs, even if the rest of the imported transaction data is the same.