### PR TITLE
chore: add delay for statusBar test assertions

### DIFF
--- a/sveltekit/package-lock.json
+++ b/sveltekit/package-lock.json
@@ -14,7 +14,7 @@
 				"semver": "^7.3.7"
 			},
 			"devDependencies": {
-				"@playwright/test": "^1.26.1",
+				"@playwright/test": "^1.27.1",
 				"@sveltejs/adapter-auto": "^1.0.0-next.75",
 				"@sveltejs/adapter-node": "^1.0.0-next.96",
 				"@sveltejs/kit": "^1.0.0-next.510",
@@ -236,13 +236,13 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.26.1",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.26.1.tgz",
-			"integrity": "sha512-bNxyZASVt2adSZ9gbD7NCydzcb5JaI0OR9hc7s+nmPeH604gwp0zp17NNpwXY4c8nvuBGQQ9oGDx72LE+cUWvw==",
+			"version": "1.27.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.27.1.tgz",
+			"integrity": "sha512-mrL2q0an/7tVqniQQF6RBL2saskjljXzqNcCOVMUjRIgE6Y38nCNaP+Dc2FBW06bcpD3tqIws/HT9qiMHbNU0A==",
 			"dev": true,
 			"dependencies": {
 				"@types/node": "*",
-				"playwright-core": "1.26.1"
+				"playwright-core": "1.27.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -2893,9 +2893,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.26.1",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.26.1.tgz",
-			"integrity": "sha512-hzFchhhxnEiPc4qVPs9q2ZR+5eKNifY2hQDHtg1HnTTUuphYCBP8ZRb2si+B1TR7BHirgXaPi48LIye5SgrLAA==",
+			"version": "1.27.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.27.1.tgz",
+			"integrity": "sha512-9EmeXDncC2Pmp/z+teoVYlvmPWUC6ejSSYZUln7YaP89Z6lpAaiaAnqroUt/BoLo8tn7WYShcfaCh+xofZa44Q==",
 			"dev": true,
 			"bin": {
 				"playwright": "cli.js"
@@ -3994,13 +3994,13 @@
 			}
 		},
 		"@playwright/test": {
-			"version": "1.26.1",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.26.1.tgz",
-			"integrity": "sha512-bNxyZASVt2adSZ9gbD7NCydzcb5JaI0OR9hc7s+nmPeH604gwp0zp17NNpwXY4c8nvuBGQQ9oGDx72LE+cUWvw==",
+			"version": "1.27.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.27.1.tgz",
+			"integrity": "sha512-mrL2q0an/7tVqniQQF6RBL2saskjljXzqNcCOVMUjRIgE6Y38nCNaP+Dc2FBW06bcpD3tqIws/HT9qiMHbNU0A==",
 			"dev": true,
 			"requires": {
 				"@types/node": "*",
-				"playwright-core": "1.26.1"
+				"playwright-core": "1.27.1"
 			}
 		},
 		"@polka/url": {
@@ -5861,9 +5861,9 @@
 			"dev": true
 		},
 		"playwright-core": {
-			"version": "1.26.1",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.26.1.tgz",
-			"integrity": "sha512-hzFchhhxnEiPc4qVPs9q2ZR+5eKNifY2hQDHtg1HnTTUuphYCBP8ZRb2si+B1TR7BHirgXaPi48LIye5SgrLAA==",
+			"version": "1.27.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.27.1.tgz",
+			"integrity": "sha512-9EmeXDncC2Pmp/z+teoVYlvmPWUC6ejSSYZUln7YaP89Z6lpAaiaAnqroUt/BoLo8tn7WYShcfaCh+xofZa44Q==",
 			"dev": true
 		},
 		"postcss": {

--- a/sveltekit/package.json
+++ b/sveltekit/package.json
@@ -15,7 +15,7 @@
 		"seed": "node prisma/seed.js"
 	},
 	"devDependencies": {
-		"@playwright/test": "^1.26.1",
+		"@playwright/test": "^1.27.1",
 		"@sveltejs/adapter-auto": "^1.0.0-next.75",
 		"@sveltejs/adapter-node": "^1.0.0-next.96",
 		"@sveltejs/kit": "^1.0.0-next.510",

--- a/sveltekit/tests/accounts.test.ts
+++ b/sveltekit/tests/accounts.test.ts
@@ -171,6 +171,7 @@ test.describe('Accounts', () => {
 		await page.locator('button', { hasText: 'Add' }).click();
 
 		const statusBar = page.locator('.statusBar');
+		await delay(); // HACK: Needed for CI
 		await expect(statusBar).toHaveClass(/statusBar--positive/);
 		await page.locator('button', { hasText: 'Dismiss' }).click();
 
@@ -188,6 +189,7 @@ test.describe('Accounts', () => {
 		await page.keyboard.type('-420.69');
 		await isExcludedCheckbox.check();
 		await page.locator('button', { hasText: 'Add' }).click();
+		await delay(); // HACK: Needed for CI
 		await expect(statusBar).toHaveClass(/statusBar--positive/);
 		expect(await tableRows.first().textContent()).toMatch('$420.69');
 		expect(await page.locator('.card', { hasText: 'Net balance' }).textContent()).toMatch(
@@ -223,6 +225,7 @@ test.describe('Accounts', () => {
 		);
 
 		const statusBar = page.locator('.statusBar');
+		await delay(); // HACK: Needed for CI
 		await expect(statusBar).not.toHaveClass(/statusBar--active/);
 		expect(await statusBar.textContent()).not.toMatch(
 			"The account —Bob's Laughable-Yield Checking— was deleted successfully"
@@ -241,6 +244,7 @@ test.describe('Accounts', () => {
 		await page.locator('button', { hasText: 'Delete' }).click();
 
 		// Check status message confirms account deletion
+		await delay(); // HACK: Needed for CI
 		await expect(statusBar).toHaveClass(/statusBar--active/);
 		expect(await statusBar.textContent()).toMatch(
 			"The account —Bob's Laughable-Yield Checking— was deleted successfully"

--- a/sveltekit/tests/accounts.test.ts
+++ b/sveltekit/tests/accounts.test.ts
@@ -104,12 +104,14 @@ test.describe('Accounts', () => {
 		await nameInput.fill('Fiat Financial Services');
 		await page.locator('button', { hasText: 'Dismiss' }).click();
 		await page.locator('button', { hasText: 'Add' }).click();
+		await delay(); // HACK: Needed for CI
 		await expect(statusBar).toHaveClass(/statusBar--negative/);
 		expect(await statusBar.textContent()).toMatch('An account with the same name already exists');
 
 		// Check an account can't be edited to have the same name as another account
 		await nameInput.fill("Alice's Savings");
 		await page.locator('button', { hasText: 'Add' }).click();
+		await delay(); // HACK: Needed for CI
 		await expect(statusBar).toHaveClass(/statusBar--positive/);
 		expect(await statusBar.textContent()).toMatch('The account was added successfully');
 		await expect(page.locator('h1', { hasText: 'Balance sheet' })).toBeVisible();
@@ -120,6 +122,7 @@ test.describe('Accounts', () => {
 
 		await nameInput.fill('Fiat Financial Services');
 		await page.locator('button', { hasText: 'Save' }).click();
+		await delay(); // HACK: Needed for CI
 		await expect(statusBar).toHaveClass(/statusBar--negative/);
 		expect(await statusBar.textContent()).toMatch('An account with the same name already exists');
 	});

--- a/sveltekit/tests/assets.test.ts
+++ b/sveltekit/tests/assets.test.ts
@@ -131,12 +131,14 @@ test.describe('Assets', () => {
 		await nameInput.fill('GameStop');
 		await page.locator('button', { hasText: 'Dismiss' }).click();
 		await page.locator('button', { hasText: 'Add' }).click();
+		await delay(); // HACK: Needed for CI
 		await expect(statusBar).toHaveClass(/statusBar--negative/);
 		expect(await statusBar.textContent()).toMatch('An asset with the same name already exists');
 
 		// Check an asset can't be edited to have the same name as another asset
 		await nameInput.fill('AMC Entertainment Holdings Inc');
 		await page.locator('button', { hasText: 'Add' }).click();
+		await delay(); // HACK: Needed for CI
 		await expect(statusBar).toHaveClass(/statusBar--positive/);
 		expect(await statusBar.textContent()).toMatch('The asset was added successfully');
 
@@ -146,6 +148,7 @@ test.describe('Assets', () => {
 		// Rename using an existing asset name
 		await nameInput.fill('GameStop');
 		await page.locator('button', { hasText: 'Save' }).click();
+		await delay(); // HACK: Needed for CI
 		await expect(statusBar).toHaveClass(/statusBar--negative/);
 		expect(await statusBar.textContent()).toMatch('An asset with the same name already exists');
 	});

--- a/sveltekit/tests/transactions.test.ts
+++ b/sveltekit/tests/transactions.test.ts
@@ -503,6 +503,7 @@ test.describe('Transactions', () => {
 
 		test('Selecting multiple transactions', async ({ page }) => {
 			const tableRows = page.locator('.table__tr');
+			await delay(); // HACK: Needed for CI
 			expect(await tableRows.count()).toBe(111);
 
 			const selectAllCheckbox = page.locator('th input.batchEditor-checkbox__input');
@@ -581,6 +582,7 @@ test.describe('Transactions', () => {
 			await selectAllCheckbox.check();
 			await selectCheckboxes.nth(0).uncheck();
 			await selectCheckboxes.nth(1).uncheck();
+			await delay(); // HACK: Needed for CI
 			expect(await tableRows.count()).toBe(111);
 			expect(await batchEditor.textContent()).toMatch('109 transactions selected');
 

--- a/sveltekit/tests/transactions.test.ts
+++ b/sveltekit/tests/transactions.test.ts
@@ -450,6 +450,7 @@ test.describe('Transactions', () => {
 		);
 
 		const statusBar = page.locator('.statusBar');
+		await delay(); // HACK: Needed for CI
 		await expect(statusBar).not.toHaveClass(/statusBar--active/);
 		expect(await statusBar.textContent()).not.toMatch(
 			'The transaction "Hølm Home" was deleted successfully'
@@ -466,6 +467,7 @@ test.describe('Transactions', () => {
 		await page.locator('button', { hasText: 'Delete' }).click();
 
 		// Check status message confirms transaction deletion
+		await delay(); // HACK: Needed for CI
 		await expect(statusBar).toHaveClass(/statusBar--active/);
 		expect(await statusBar.textContent()).toMatch(
 			'The transaction —Hølm Home— was deleted successfully'
@@ -484,6 +486,7 @@ test.describe('Transactions', () => {
 		await page.locator('button', { hasText: 'Delete' }).click();
 
 		// Check status message shows an error
+		await delay(); // HACK: Needed for CI
 		await expect(statusBar).toHaveClass(/statusBar--negative/);
 		expect(await statusBar.textContent()).toMatch("The transaction doesn't exist");
 	});
@@ -600,7 +603,7 @@ test.describe('Transactions', () => {
 			await expect(statusBar).not.toHaveClass(/statusBar--active/);
 
 			await page.locator('button', { hasText: 'Delete' }).click();
-
+			await delay(); // HACK: Needed for CI
 			await expect(statusBar).toHaveClass(/statusBar--active/);
 			expect(await statusBar.textContent()).toMatch('109 transactions were deleted successfully');
 
@@ -738,7 +741,7 @@ test.describe('Transactions', () => {
 			await expect(statusBar).not.toHaveClass(/statusBar--positive/);
 
 			await applyButton.click();
-
+			await delay(); // HACK: Needed for CI
 			await expect(statusBar).toHaveClass(/statusBar--positive/);
 			expect(await statusBar.textContent()).toMatch('The 2 transactions were updated successfully');
 
@@ -768,7 +771,7 @@ test.describe('Transactions', () => {
 			await page.locator('a', { hasText: 'Accidentes? Llámenos 1-800-877-7770' }).first().click();
 			await dateSelect.selectOption({ label: '29' });
 			await page.locator('button', { hasText: 'Save' }).click();
-
+			await delay(); // HACK: Needed for CI
 			await expect(statusBar).toHaveClass(/statusBar--positive/);
 			expect(await statusBar.textContent()).toMatch('The transaction was updated successfully');
 
@@ -829,6 +832,7 @@ test.describe('Transactions', () => {
 			expect(await amountInput.inputValue()).toMatch('$999');
 
 			await applyButton.click();
+			await delay(); // HACK: Needed for CI
 			await expect(statusBar).toHaveClass(/statusBar--positive/);
 			expect(await statusBar.textContent()).toMatch('The 2 transactions were updated successfully');
 

--- a/sveltekit/tests/transactions.test.ts
+++ b/sveltekit/tests/transactions.test.ts
@@ -82,6 +82,7 @@ test.describe('Transactions', () => {
 		expect(await cardNetBalance.textContent()).toMatch('Net balance');
 
 		const tableRows = page.locator('.table__tr');
+		await delay(); // HACK: Needed for CI
 		expect(await tableRows.count()).toBe(111);
 		expect(await tableRows.first().textContent()).toMatch('Toyota - TFS Payment');
 		expect(await tableRows.first().textContent()).toMatch('Automotive');


### PR DESCRIPTION
Tests in CI appear to run slow enough that some test assertions (in particular those related to `statusBar`) fail often.

This fix introduces a `delay()` before each `statusBar` test assertion to hopefully reduce the number of test retries.