### PR TITLE
fix: cashflow chart bar ratios

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,9 +43,9 @@ jobs:
         working-directory: ./sveltekit
         run: npm test
         env:
-          IS_ELECTRON: "true"
           NODE_ENV: CI
           BROWSER: ${{ matrix.browser }}
+          USE_HTTP: "true"
 
       - uses: actions/upload-artifact@v3
         if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,7 @@ jobs:
         working-directory: ./sveltekit
         run: npm test
         env:
+          IS_ELECTRON: "true"
           NODE_ENV: CI
           BROWSER: ${{ matrix.browser }}
 

--- a/electron/__tests__/server.spec.ts
+++ b/electron/__tests__/server.spec.ts
@@ -14,7 +14,7 @@ describe("Server", () => {
     SVELTEKIT_PATH: fakePathToSvelteKitIndex,
     DATABASE_URL: `file:${fakePathToVault}`,
     SHOULD_CHECK_VAULT: "true",
-    IS_ELECTRON: "true",
+    USE_HTTP: "true",
     APP_VERSION: require("../../package.json").version,
   };
 

--- a/electron/server.ts
+++ b/electron/server.ts
@@ -44,7 +44,7 @@ class Server {
         SVELTEKIT_PATH: svelteKitPath,
         DATABASE_URL: `file:${newVaultPath ? newVaultPath : this.vaultPath}`,
         SHOULD_CHECK_VAULT: "true",
-        IS_ELECTRON: "true",
+        USE_HTTP: "true",
         APP_VERSION: isDev
           ? require("../package.json").version
           : app.getVersion(),

--- a/sveltekit/src/hooks.server.ts
+++ b/sveltekit/src/hooks.server.ts
@@ -12,7 +12,7 @@ import {
 const redirectTo = (origin: string, route: string) => {
 	// When the app runs as an Electron app it doesn't have an SSL certificate
 	const url = new URL(origin);
-	url.protocol = process.env.IS_ELECTRON === 'true' ? 'http:' : 'https:';
+	url.protocol = process.env.USE_HTTP === 'true' ? 'http:' : 'https:';
 	return Response.redirect(`${url.origin}${route}`, 307);
 };
 

--- a/sveltekit/src/lib/components/ChartBar.svelte
+++ b/sveltekit/src/lib/components/ChartBar.svelte
@@ -32,16 +32,16 @@
 
 	{#if trend === 'positive' || trend === 'negative'}
 		<div class="chart__bar {trend && `chart__bar--${trend}`}">
-			<p class="chart__label {isLabelVisible && 'chart__label--visible'}">
-				{value}
-			</p>
-
 			<div
 				class="chart__graph {isActive &&
 					!isCurrentPeriod &&
 					'chart__graph--active'} {isCurrentPeriod && 'chart__graph--currentPeriod'}"
 				style={`${barHeight} ${barBackground}`}
-			/>
+			>
+				<p class="chart__label {isLabelVisible && 'chart__label--visible'}">
+					{value}
+				</p>
+			</div>
 		</div>
 	{:else}
 		<div class="chart__barPlaceholder" />
@@ -62,6 +62,7 @@
 		height: 50vh;
 		min-height: 256px;
 		max-height: 320px;
+		padding: 32px 0;
 		box-sizing: border-box;
 	}
 
@@ -69,21 +70,21 @@
 		display: flex;
 		flex-direction: column;
 		width: 100%;
-		min-height: 32px;
-		overflow: hidden;
 		color: var(--color-grey50);
 		border: none;
 
 		&--positive {
 			color: var(--color-greenPrimary);
+			height: 100%;
 
 			p.chart__label {
-				margin-top: auto;
+				top: -32px;
+				padding-bottom: 12px;
 			}
 
 			div.chart__graph {
-				padding-top: 8px;
 				border-top: 3px solid var(--color-greenPrimary);
+				margin-top: auto;
 
 				&:not(div.chart__graph--currentPeriod, div.chart__graph--active) {
 					background-color: var(--color-greenSecondary);
@@ -96,15 +97,17 @@
 		}
 
 		&--negative {
-			flex-direction: column-reverse;
 			color: var(--color-redPrimary);
+			height: 100%;
 
 			p.chart__label {
-				margin-bottom: auto;
+				bottom: -32px;
+				padding-top: 12px;
 			}
 
 			div.chart__graph {
 				border-bottom: 3px solid var(--color-redPrimary);
+				margin-bottom: auto;
 
 				&:not(div.chart__graph--currentPeriod, div.chart__graph--active) {
 					background-color: var(--color-redSecondary);
@@ -118,6 +121,8 @@
 	}
 
 	div.chart__graph {
+		position: relative;
+
 		&--currentPeriod {
 			background-color: var(--color-white);
 			background-image: var(--background-url);
@@ -126,13 +131,16 @@
 	}
 
 	p.chart__label {
+		position: absolute;
+		width: 100%;
+		box-sizing: border-box;
+		padding: 8px 4px;
 		font-family: var(--font-monospace);
 		font-size: 12px;
-		min-height: 12px;
+		line-height: 1em;
 		margin: 0;
-		padding: 12px 4px 8px 4px;
-		text-align: center;
 		opacity: 0;
+		text-align: center;
 		overflow: hidden;
 		text-overflow: ellipsis;
 
@@ -146,9 +154,5 @@
 		height: 1px;
 		margin: 0;
 		background-color: var(--color-border);
-	}
-
-	div.chart__barPlaceholder {
-		min-height: 32px;
 	}
 </style>


### PR DESCRIPTION
Makes the height of the chart bars accurately reflect the difference between the low and high values.

This is achieved by positioning the `p.chart__label` absolutely so it's height doesn't count towards the height of the bar.