### PR TITLE
fix: Electron app waits until the server is ready before switching to it

### DIFF
--- a/electron/__tests__/__snapshots__/tray-menu.spec.ts.snap
+++ b/electron/__tests__/__snapshots__/tray-menu.spec.ts.snap
@@ -6,7 +6,7 @@ exports[`TrayMenu tray is set with the correct parameters 1`] = `
     "enabled": false,
     "icon": "./resources/assets/dev/dev-canutin-tray-active-light.png",
     "id": "menu-server-status",
-    "label": "Canutin is running",
+    "label": "Canutin is not running",
   },
   {
     "type": "separator",
@@ -14,8 +14,8 @@ exports[`TrayMenu tray is set with the correct parameters 1`] = `
   {
     "click": [Function],
     "id": "menu-server-toggle",
-    "label": "Stop Canutin",
-    "visible": true,
+    "label": "Start Canutin",
+    "visible": false,
   },
   {
     "type": "separator",

--- a/electron/server.ts
+++ b/electron/server.ts
@@ -1,15 +1,15 @@
 import path from "path";
 import { app } from "electron";
-import { fork } from "child_process";
+import { fork, ChildProcess } from "child_process";
 
 class Server {
   static readonly PORT_DEVELOPMENT = "3000";
   static readonly PORT_PRODUCTION = "42069";
 
-  private vaultPath: string;
   private isAppPackaged: boolean;
+  private vaultPath: string;
   private port: string;
-  private pid: number | undefined;
+  private serverProcess: ChildProcess | null = null;
   readonly url: string;
   isRunning: boolean;
 
@@ -23,45 +23,53 @@ class Server {
     this.url = `http://localhost:${this.port}`;
   }
 
-  start(newVaultPath?: string) {
-    const HOST = "127.0.0.1";
-    const isAppPackaged = this.isAppPackaged;
-    const isDev = process.env.NODE_ENV == "development";
+  start(newVaultPath?: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const HOST = "127.0.0.1";
+      const isAppPackaged = this.isAppPackaged;
+      const isDev = process.env.NODE_ENV == "development";
 
-    const svelteKitPath = isAppPackaged
-      ? path.join(process.resourcesPath, "sveltekit")
-      : path.join(__dirname, "../../sveltekit");
+      const svelteKitPath = isAppPackaged
+        ? path.join(process.resourcesPath, "sveltekit")
+        : path.join(__dirname, "../../sveltekit");
 
-    const svelteKitModulePath = isAppPackaged
-      ? path.join(svelteKitPath, "index.js")
-      : path.join(svelteKitPath, "build", "index.js");
+      const svelteKitModulePath = isAppPackaged
+        ? path.join(svelteKitPath, "index.js")
+        : path.join(svelteKitPath, "build", "index.js");
 
-    const svelteKitProcess = fork(svelteKitModulePath, {
-      env: {
-        ...process.env,
-        HOST,
-        PORT: this.port,
-        SVELTEKIT_PATH: svelteKitPath,
-        DATABASE_URL: `file:${newVaultPath ? newVaultPath : this.vaultPath}`,
-        SHOULD_CHECK_VAULT: "true",
-        APP_VERSION: isDev
-          ? require("../package.json").version
-          : app.getVersion(),
-      },
+      this.serverProcess = fork(svelteKitModulePath, {
+        env: {
+          ...process.env,
+          HOST,
+          PORT: this.port,
+          SVELTEKIT_PATH: svelteKitPath,
+          DATABASE_URL: `file:${newVaultPath ? newVaultPath : this.vaultPath}`,
+          SHOULD_CHECK_VAULT: "true",
+          APP_VERSION: isDev
+            ? require("../package.json").version
+            : app.getVersion(),
+        },
+      });
+
+      this.serverProcess.on('message', (message: any) => {
+        if (message === 'sveltekit-server-ready') {
+          this.isRunning = true;
+          isDev && console.info(`\n-> Server started at ${this.url}\n`);
+          resolve();
+        }
+      });
+
+      this.serverProcess.on('error', (err) => {
+        reject(err);
+      });
     });
-
-    this.pid = svelteKitProcess.pid; // Set process id so we can kill it private later
-    this.isRunning = this.pid ? true : false;
-
-    // Loggin the url to the console in development so it's easier to click
-    isDev && console.info(`\n-> Server started at ${this.url}\n`);
   }
 
   stop() {
-    if (!this.pid) return;
-
-    process.kill(this.pid);
-    this.pid = undefined;
+    if (this.serverProcess) {
+      this.serverProcess.kill();
+      this.serverProcess = null;
+    }
     this.isRunning = false;
   }
 }

--- a/electron/server.ts
+++ b/electron/server.ts
@@ -50,8 +50,8 @@ class Server {
       },
     });
 
-    this.isRunning = true;
     this.pid = svelteKitProcess.pid; // Set process id so we can kill it private later
+    this.isRunning = this.pid ? true : false;
 
     // Loggin the url to the console in development so it's easier to click
     isDev && console.info(`\n-> Server started at ${this.url}\n`);
@@ -62,6 +62,7 @@ class Server {
 
     process.kill(this.pid);
     this.pid = undefined;
+    this.isRunning = false;
   }
 }
 

--- a/electron/tray-menu.ts
+++ b/electron/tray-menu.ts
@@ -155,17 +155,15 @@ class TrayMenu {
       // Start the server
       try {
         await this.server.start(vaultPath);
+
+        // Now we know the server is up and running
+        this.window.loadURL(this.server.url);
         this.menuServerToggle.visible = true;
         this.menuServerToggle.label = "Stop Canutin";
         this.menuServerStatus.label = "Canutin is running";
-        this.menuServerStatus.icon = this.getImagePath(
-          TrayMenu.ICON_STATUS_POSITIVE
-        );
+        this.menuServerStatus.icon = this.getImagePath(TrayMenu.ICON_STATUS_POSITIVE);
         this.setTrayIcon(TrayMenu.ICON_TRAY_ACTIVE);
         this.updateTray();
-
-        // Now we can safely load the URL as we know the server is running
-        this.window.loadURL(this.server.url);
       } catch (error) {
         console.error("Failed to start server:", error);
         // TODO: Handle the error appropriately (e.g., show an error message to the user)

--- a/electron/tray-menu.ts
+++ b/electron/tray-menu.ts
@@ -25,7 +25,6 @@ class TrayMenu {
   static readonly ICON_STATUS_POSITIVE = "status-positive";
   static readonly ICON_STATUS_NEGATIVE = "status-negative";
 
-  private isServerRunning: boolean;
   private isAppPackaged: boolean;
   private isMacOs: boolean;
 
@@ -46,7 +45,6 @@ class TrayMenu {
   constructor(vault: Vault, window: BrowserWindow) {
     this.vault = vault;
     this.window = window;
-    this.isServerRunning = false;
     this.isAppPackaged = app.isPackaged || false;
     this.trayIcon = TrayMenu.ICON_TRAY_IDLE;
 
@@ -132,12 +130,8 @@ class TrayMenu {
       this.updateTray();
 
       // Starting (or restarting) the server
-      if (this.isServerRunning) {
-        this.toggleServer(); // Stops the server
-        this.toggleServer(); // Starts the server
-      } else {
-        this.toggleServer(); // Starts the server
-      }
+      if (this.server?.isRunning) this.server.stop();
+      this.server?.start(vault.path);
     }
   };
 
@@ -146,7 +140,7 @@ class TrayMenu {
 
     if (!this.server && vaultPath) this.server = new Server(vaultPath);
 
-    if (this.server && this.isServerRunning) {
+    if (this.server?.isRunning) {
       // Stop the server
       this.server.stop();
       this.menuServerToggle.label = "Start Canutin";
@@ -175,12 +169,6 @@ class TrayMenu {
       setTimeout(() => this.server && this.window.loadURL(this.server.url), TrayMenu.LOAD_SERVER_URL_DELAY);
       ;
     }
-
-    // FIXME:
-    // It would be better to check if the server is actually running (or not)
-    // instead of blindingly reversing the vaule of `isServerRunning`.
-    // REF: https://github.com/Canutin/desktop-2/issues/8
-    this.isServerRunning = !this.isServerRunning;
   };
 
   private updateTray() {

--- a/electron/tray-menu.ts
+++ b/electron/tray-menu.ts
@@ -135,7 +135,7 @@ class TrayMenu {
     }
   };
 
-  private toggleServer() {
+  private async toggleServer() {
     const vaultPath = this.vault?.path;
 
     if (!this.server && vaultPath) this.server = new Server(vaultPath);
@@ -153,21 +153,23 @@ class TrayMenu {
       this.setLoadingView();
     } else if (this.server) {
       // Start the server
-      this.server.start(vaultPath);
-      this.menuServerToggle.visible = true;
-      this.menuServerToggle.label = "Stop Canutin";
-      this.menuServerStatus.label = "Canutin is running";
-      this.menuServerStatus.icon = this.getImagePath(
-        TrayMenu.ICON_STATUS_POSITIVE
-      );
-      this.setTrayIcon(TrayMenu.ICON_TRAY_ACTIVE);
-      this.updateTray();
+      try {
+        await this.server.start(vaultPath);
+        this.menuServerToggle.visible = true;
+        this.menuServerToggle.label = "Stop Canutin";
+        this.menuServerStatus.label = "Canutin is running";
+        this.menuServerStatus.icon = this.getImagePath(
+          TrayMenu.ICON_STATUS_POSITIVE
+        );
+        this.setTrayIcon(TrayMenu.ICON_TRAY_ACTIVE);
+        this.updateTray();
 
-      // FIXME:
-      // Should set the server URL after the server is actually running.
-      // REF: https://github.com/Canutin/desktop-2/issues/8
-      setTimeout(() => this.server && this.window.loadURL(this.server.url), TrayMenu.LOAD_SERVER_URL_DELAY);
-      ;
+        // Now we can safely load the URL as we know the server is running
+        this.window.loadURL(this.server.url);
+      } catch (error) {
+        console.error("Failed to start server:", error);
+        // TODO: Handle the error appropriately (e.g., show an error message to the user)
+      }
     }
   };
 

--- a/sveltekit/src/hooks.server.ts
+++ b/sveltekit/src/hooks.server.ts
@@ -10,6 +10,9 @@ import {
 } from '$lib/helpers/constants';
 
 export const handle: Handle = async ({ event, resolve }) => {
+	// Let Electron know the server is up and running
+	if (process.send) process.send('sveltekit-server-ready');
+
 	// Simulate an internal server error by visiting `/500` in dev
 	if (dev && event.url.pathname.startsWith('/500'))
 		throw new Error(

--- a/sveltekit/src/hooks.server.ts
+++ b/sveltekit/src/hooks.server.ts
@@ -9,9 +9,14 @@ import {
 	UNAUTHORIZED_RESPONSE_STATUS
 } from '$lib/helpers/constants';
 
+let wasElectronNotified = false;
+
 export const handle: Handle = async ({ event, resolve }) => {
-	// Let Electron know the server is up and running
-	if (process.send) process.send('sveltekit-server-ready');
+	// Let Electron know the server is up and running, and send the server URL
+	if (!wasElectronNotified && process.send) {
+		process.send('sveltekit-server-ready');
+		wasElectronNotified = true;
+	}
 
 	// Simulate an internal server error by visiting `/500` in dev
 	if (dev && event.url.pathname.startsWith('/500'))


### PR DESCRIPTION
Closes #8 

SvelteKit's server sends a message to Electron via `process` when the server is up and running.
Then Electron loads the `hostname` in the `BrowserWindow`.