### PR TITLE
fix: starts server in the background and loads UI in an Electron window

### DIFF
--- a/electron/__mocks__/electron.ts
+++ b/electron/__mocks__/electron.ts
@@ -50,12 +50,20 @@ const BrowserWindow = jest.fn(() => ({
   loadURL: jest.fn(),
 }));
 
+const MessageChannelMain = jest.fn();
+
+const utilityProcess = {
+  fork: jest.fn(),
+};
+
 module.exports = {
   app,
   shell,
   dialog,
   nativeTheme,
+  utilityProcess,
   Menu,
   Tray,
-  BrowserWindow
+  BrowserWindow,
+  MessageChannelMain,
 };

--- a/electron/__tests__/tray-menu.spec.ts
+++ b/electron/__tests__/tray-menu.spec.ts
@@ -1,6 +1,5 @@
 import path from "path";
-import { BrowserWindow } from "electron";
-import Electron, { Menu } from "electron";
+import Electron, { Menu, BrowserWindow } from "electron";
 
 import TrayMenu from "../tray-menu";
 import Vault from "../vault";
@@ -50,13 +49,8 @@ describe("TrayMenu", () => {
       TrayMenu.prototype as TrayMenuWithPrivateMethods,
       "toggleServer"
     );
-    const spySetLoadingView = jest.spyOn(
-      TrayMenu.prototype as TrayMenuWithPrivateMethods,
-      "setLoadingView"
-    );
     const trayMenu = new TrayMenu(vault, mockBrowserWindow);
     const tray = trayMenu["tray"];
-    expect(spySetLoadingView).toHaveBeenCalled();
     expect(spyToggleServer).toHaveBeenCalled();
     expect(spyGetImagePath).toHaveBeenCalledWith(TrayMenu.ICON_TRAY_IDLE);
     expect(trayMenu["menuCurrentTemplate"]).toMatchSnapshot();

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,15 +1,13 @@
-import { BrowserWindow, app, screen } from "electron";
+import { BrowserWindow, app } from "electron";
 
 import TrayMenu from "./tray-menu";
 import Vault from "./vault";
-import { browserWindowConfig } from "./window";
+import { browserWindowConfig, setLoadingView } from "./window";
 
 enum ElectronEvents {
   READY = 'ready',
   BEFORE_QUIT = 'before-quit'
 }
-
-process.platform === "darwin" && app.dock.hide(); // Hide dock icon on macOS
 
 let trayMenu: TrayMenu | undefined;
 
@@ -18,8 +16,8 @@ app.on(ElectronEvents.READY, () => {
   const vault = new Vault();
   if (!vault.path) vault.dialog();
 
-  const { width, height } = screen.getPrimaryDisplay().workAreaSize;
-  const window = new BrowserWindow(browserWindowConfig(width, height));
+  const window = new BrowserWindow(browserWindowConfig());
+  setLoadingView(window);
 
   trayMenu = new TrayMenu(vault, window);
 });

--- a/electron/server.ts
+++ b/electron/server.ts
@@ -4,7 +4,16 @@ import { app, BrowserWindow, MessageChannelMain, utilityProcess, UtilityProcess 
 import { ELECTRON_MESSAGE_SERVER_READY } from "../sveltekit/src/lib/helpers/electron";
 import { setLoadingView } from "./window";
 
-const SERVER_READY_DELAY_IN_MS = 1500;
+function serverDelayInMilliseconds(): number {
+  switch (process.env.NODE_ENV) {
+    case "development":
+      return 500;
+    case "test":
+      return 0;
+    default:
+      return 1500;
+  }
+}
 
 class Server {
   static readonly PORT_DEVELOPMENT = "3000";
@@ -33,7 +42,7 @@ class Server {
     return new Promise((resolve, reject) => {
       const HOST = "127.0.0.1";
       const isAppPackaged = this.isAppPackaged;
-      const isDev = process.env.NODE_ENV == "development";
+      const isDev = process.env.NODE_ENV && ["development", "test"].includes(process.env.NODE_ENV);
 
       const svelteKitPath = isAppPackaged
         ? path.join(process.resourcesPath, "sveltekit")
@@ -79,7 +88,7 @@ class Server {
             this.isRunning = true;
             this.window.loadURL(this.url);
             resolve();
-          }, SERVER_READY_DELAY_IN_MS);
+          }, serverDelayInMilliseconds());
 
         } catch (error) {
           reject(error);

--- a/electron/server.ts
+++ b/electron/server.ts
@@ -97,6 +97,7 @@ class Server {
 
       this.serverProcess.on('exit', (code) => {
         this.isRunning = false;
+        this.serverProcess = null;
         if (code !== 0) reject(new Error(`-> Server process exited with code ${code}`));
       });
     });
@@ -106,7 +107,6 @@ class Server {
     if (!this.serverProcess) return;
     setLoadingView(this.window);
     this.serverProcess.kill();
-    this.serverProcess = null;
   }
 }
 

--- a/electron/tray-menu.ts
+++ b/electron/tray-menu.ts
@@ -10,7 +10,6 @@ import {
 
 import Vault from "./vault";
 import Server from "./server";
-import { setLoadingView } from "./window";
 
 class TrayMenu {
   static readonly LOAD_SERVER_URL_DELAY = 500;
@@ -161,7 +160,6 @@ class TrayMenu {
         this.setTrayIcon(TrayMenu.ICON_TRAY_ACTIVE);
         this.updateTray();
       } catch (error) {
-        console.error("Failed to start server:", error);
         // TODO: Handle the error appropriately (e.g., show an error message to the user)
       }
     }

--- a/electron/tray-menu.ts
+++ b/electron/tray-menu.ts
@@ -10,6 +10,7 @@ import {
 
 import Vault from "./vault";
 import Server from "./server";
+import { setLoadingView } from "./window";
 
 class TrayMenu {
   static readonly LOAD_SERVER_URL_DELAY = 500;
@@ -47,9 +48,6 @@ class TrayMenu {
     this.window = window;
     this.isAppPackaged = app.isPackaged || false;
     this.trayIcon = TrayMenu.ICON_TRAY_IDLE;
-
-    // Set loading window
-    this.setLoadingView();
 
     // There's a snapshot test that checks the menu template and we don't want
     // to use macOS keyboard shortcuts when generating the template.
@@ -124,7 +122,7 @@ class TrayMenu {
   private switchVault() {
     const { vault } = this;
     const isVaultSet = vault.dialog();
-
+    
     if (isVaultSet && vault.path) {
       this.menuVaultPath.label = vault.path;
       this.updateTray();
@@ -138,7 +136,7 @@ class TrayMenu {
   private async toggleServer() {
     const vaultPath = this.vault?.path;
 
-    if (!this.server && vaultPath) this.server = new Server(vaultPath);
+    if (!this.server && vaultPath) this.server = new Server(vaultPath, this.window);
 
     if (this.server?.isRunning) {
       // Stop the server
@@ -150,7 +148,6 @@ class TrayMenu {
       );
       this.setTrayIcon(TrayMenu.ICON_TRAY_IDLE);
       this.updateTray();
-      this.setLoadingView();
     } else if (this.server) {
       // Start the server
       try {
@@ -163,7 +160,6 @@ class TrayMenu {
         this.menuServerStatus.icon = this.getImagePath(TrayMenu.ICON_STATUS_POSITIVE);
         this.setTrayIcon(TrayMenu.ICON_TRAY_ACTIVE);
         this.updateTray();
-        this.window.loadURL(this.server.url);
       } catch (error) {
         console.error("Failed to start server:", error);
         // TODO: Handle the error appropriately (e.g., show an error message to the user)
@@ -194,16 +190,6 @@ class TrayMenu {
         ? "assets/dev/dev-"
         : "assets/"
       }${fileName}${theme}.png`;
-  }
-
-  private setLoadingView() {
-    const LOADING_HTML = "loading.html";
-
-    if (this.isAppPackaged) {
-      this.window.loadFile(path.join(process.resourcesPath, 'assets', LOADING_HTML));
-    } else {
-      this.window.loadFile(`../../resources/assets/${LOADING_HTML}`);
-    }
   }
 
   private setTrayIcon = (icon: string) => {

--- a/electron/tray-menu.ts
+++ b/electron/tray-menu.ts
@@ -121,7 +121,7 @@ class TrayMenu {
   private switchVault() {
     const { vault } = this;
     const isVaultSet = vault.dialog();
-    
+
     if (isVaultSet && vault.path) {
       this.menuVaultPath.label = vault.path;
       this.updateTray();

--- a/electron/window.ts
+++ b/electron/window.ts
@@ -1,3 +1,6 @@
+import { BrowserWindow, BrowserWindowConstructorOptions, app, nativeTheme, screen } from "electron";
+import path from "path";
+
 const MIN_WINDOW_WIDTH = 1200;
 const MIN_WINDOW_HEIGHT = 768;
 const MAX_WINDOW_WIDTH = 1440;
@@ -27,11 +30,24 @@ const calculateWindowHeight = (displayHeight: number) => {
   }
 };
 
-export const browserWindowConfig = (width: number, height: number) => {
+export const browserWindowConfig = (): BrowserWindowConstructorOptions => {
+  const { width, height } = screen.getPrimaryDisplay().workAreaSize;
+
   return {
     minWidth: MIN_WINDOW_WIDTH,
     minHeight: MIN_WINDOW_HEIGHT,
     width: calculateWindowWidth(width),
     height: calculateWindowHeight(height),
+    backgroundColor: nativeTheme.shouldUseDarkColors ? "#1c1c1c" : "#e3e3e3",
+  }
+}
+
+export const setLoadingView = (window: BrowserWindow) => {
+  const LOADING_HTML = "loading.html";
+
+  if (app.isPackaged) {
+    window.loadFile(path.join(process.resourcesPath, 'assets', LOADING_HTML));
+  } else {
+    window.loadFile(`../../resources/assets/${LOADING_HTML}`);
   }
 }

--- a/electron/window.ts
+++ b/electron/window.ts
@@ -5,6 +5,7 @@ const MIN_WINDOW_WIDTH = 1200;
 const MIN_WINDOW_HEIGHT = 768;
 const MAX_WINDOW_WIDTH = 1440;
 const MAX_WINDOW_HEIGHT = 1200;
+const LOADING_HTML = "loading.html";
 
 const calculateWindowWidth = (displayWidth: number) => {
   const relativeWindowWidth = Math.floor(displayWidth * 0.7);
@@ -43,8 +44,6 @@ export const browserWindowConfig = (): BrowserWindowConstructorOptions => {
 }
 
 export const setLoadingView = (window: BrowserWindow) => {
-  const LOADING_HTML = "loading.html";
-
   if (app.isPackaged) {
     window.loadFile(path.join(process.resourcesPath, 'assets', LOADING_HTML));
   } else {

--- a/sveltekit/prisma/schema.prisma
+++ b/sveltekit/prisma/schema.prisma
@@ -1,5 +1,6 @@
 generator client {
-  provider = "prisma-client-js"
+  provider      = "prisma-client-js"
+  binaryTargets = ["native", "darwin"]
 }
 
 datasource db {

--- a/sveltekit/src/hooks.server.ts
+++ b/sveltekit/src/hooks.server.ts
@@ -8,16 +8,11 @@ import {
 	UNAUTHORIZED_RESPONSE_MESSAGE,
 	UNAUTHORIZED_RESPONSE_STATUS
 } from '$lib/helpers/constants';
+import { notifyElectronServerReady } from '$lib/helpers/electron';
 
-let wasElectronNotified = false;
+if (env.IS_ELECTRON) notifyElectronServerReady();
 
 export const handle: Handle = async ({ event, resolve }) => {
-	// Let Electron know the server is up and running, and send the server URL
-	if (!wasElectronNotified && process.send) {
-		process.send('sveltekit-server-ready');
-		wasElectronNotified = true;
-	}
-
 	// Simulate an internal server error by visiting `/500` in dev
 	if (dev && event.url.pathname.startsWith('/500'))
 		throw new Error(

--- a/sveltekit/src/lib/helpers/electron.ts
+++ b/sveltekit/src/lib/helpers/electron.ts
@@ -1,0 +1,16 @@
+export const ELECTRON_MESSAGE_SERVER_READY = 'sveltekit-server-ready';
+
+enum ElectronStatus {
+  IS_NOTIFIED,
+  IS_NOT_NOTIFIED
+}
+
+let electronStatus: ElectronStatus = ElectronStatus.IS_NOT_NOTIFIED;
+ 
+export function notifyElectronServerReady() {
+  // Notify Electron that the server is ready (only once)
+  if (electronStatus === ElectronStatus.IS_NOT_NOTIFIED) {
+    process.parentPort.postMessage(ELECTRON_MESSAGE_SERVER_READY);
+    electronStatus = ElectronStatus.IS_NOTIFIED;
+  }
+}


### PR DESCRIPTION
- Replaces `fork` with Electron's [`utilityProcess`](https://www.electronjs.org/docs/latest/api/utility-process)
- SvelteKit sends a message `ELECTRON_MESSAGE_SERVER_READY` to the parent Electron process
- Electron sends an initial `fetch()` request to initialize the server (run migrations, etc)
- Electron flags the server as `isRunning`