### PR TITLE
fix: improve mobile layout across the restructured UI

### DIFF
--- a/e2e/trends.performance.test.ts
+++ b/e2e/trends.performance.test.ts
@@ -15,7 +15,7 @@ import {
 	seedUser
 } from './pocketbase.helpers';
 
-test('trends performance table', async ({ page, isMobile }) => {
+test('trends performance table', async ({ page }) => {
 	const user = await seedUser('steve');
 
 	await page.goto('/');
@@ -354,13 +354,12 @@ test('trends performance table', async ({ page, isMobile }) => {
 	// full-range domain to just the visible series (cash 1,000..8,000, padded then niced
 	// by the scale to 0..9,000). Tick texts are scoped to the growth chart because the
 	// per-group cash chart below nices to the same $9,000 tick.
-	// Narrow viewports compact axis labels above $10,000, so the top tick reads $45K there.
-	const fullRangeTick = isMobile ? '$45K' : '$45,000';
-	await expect(maxChart.getByText(fullRangeTick, { exact: true })).toBeVisible();
+	// Axis labels compact above $10,000 on every viewport, so the top tick reads $45K.
+	await expect(maxChart.getByText('$45K', { exact: true })).toBeVisible();
 	await expect(maxChart.getByText('$9,000', { exact: true })).not.toBeVisible();
 	await page.getByRole('button', { name: 'Cash', exact: true }).click();
 	await expect(maxChart.getByText('$9,000', { exact: true })).toBeVisible();
-	await expect(maxChart.getByText(fullRangeTick, { exact: true })).not.toBeVisible();
+	await expect(maxChart.getByText('$45K', { exact: true })).not.toBeVisible();
 	// Recapture the box: the legend click can scroll the chart and stale coords miss it
 	await dragChart(page, maxChart, 0, 1, 0.6, 4);
 	await expect(compareTooltip.getByText('+$7,000')).toBeVisible();
@@ -369,7 +368,7 @@ test('trends performance table', async ({ page, isMobile }) => {
 
 	// Toggling the series back restores the full-range y-axis
 	await page.getByRole('button', { name: 'Cash', exact: true }).click();
-	await expect(maxChart.getByText(fullRangeTick, { exact: true })).toBeVisible();
+	await expect(maxChart.getByText('$45K', { exact: true })).toBeVisible();
 	await expect(maxChart.getByText('$9,000', { exact: true })).not.toBeVisible();
 
 	// Each chart windows independently: switching the Cash group chart to 2Y leaves the growth

--- a/e2e/trends.performance.test.ts
+++ b/e2e/trends.performance.test.ts
@@ -15,7 +15,7 @@ import {
 	seedUser
 } from './pocketbase.helpers';
 
-test('trends performance table', async ({ page }) => {
+test('trends performance table', async ({ page, isMobile }) => {
 	const user = await seedUser('steve');
 
 	await page.goto('/');
@@ -354,11 +354,13 @@ test('trends performance table', async ({ page }) => {
 	// full-range domain to just the visible series (cash 1,000..8,000, padded then niced
 	// by the scale to 0..9,000). Tick texts are scoped to the growth chart because the
 	// per-group cash chart below nices to the same $9,000 tick.
-	await expect(maxChart.getByText('$45,000', { exact: true })).toBeVisible();
+	// Narrow viewports compact axis labels above $10,000, so the top tick reads $45K there.
+	const fullRangeTick = isMobile ? '$45K' : '$45,000';
+	await expect(maxChart.getByText(fullRangeTick, { exact: true })).toBeVisible();
 	await expect(maxChart.getByText('$9,000', { exact: true })).not.toBeVisible();
 	await page.getByRole('button', { name: 'Cash', exact: true }).click();
 	await expect(maxChart.getByText('$9,000', { exact: true })).toBeVisible();
-	await expect(maxChart.getByText('$45,000', { exact: true })).not.toBeVisible();
+	await expect(maxChart.getByText(fullRangeTick, { exact: true })).not.toBeVisible();
 	// Recapture the box: the legend click can scroll the chart and stale coords miss it
 	await dragChart(page, maxChart, 0, 1, 0.6, 4);
 	await expect(compareTooltip.getByText('+$7,000')).toBeVisible();
@@ -367,7 +369,7 @@ test('trends performance table', async ({ page }) => {
 
 	// Toggling the series back restores the full-range y-axis
 	await page.getByRole('button', { name: 'Cash', exact: true }).click();
-	await expect(maxChart.getByText('$45,000', { exact: true })).toBeVisible();
+	await expect(maxChart.getByText(fullRangeTick, { exact: true })).toBeVisible();
 	await expect(maxChart.getByText('$9,000', { exact: true })).not.toBeVisible();
 
 	// Each chart windows independently: switching the Cash group chart to 2Y leaves the growth

--- a/src/app.css
+++ b/src/app.css
@@ -224,4 +224,21 @@
 			border-radius: 0;
 		}
 	}
+
+	/* Free text in a table cell - descriptions, account and security names - has no length limit, and
+	   on a phone a long value either wraps into a stack of one-word lines or drags the rest of the
+	   columns off screen. Below `sm` it is capped and clipped to a single line instead. `max-width`
+	   has no effect on a `td` in an auto table layout, so the cap has to sit on the text element
+	   inside the cell; that also keeps a link's clip box identical to its own box, so it stays
+	   tappable. The DOM text is untouched - call sites carry a `title` with the full value. */
+	@media (width < 40rem) {
+		.cell-truncate {
+			display: inline-block;
+			max-width: 18ch;
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+			vertical-align: middle;
+		}
+	}
 }

--- a/src/app.css
+++ b/src/app.css
@@ -61,6 +61,10 @@
 	--card-foreground: oklch(0.145 0 0);
 	--popover: oklch(1 0 0);
 	--popover-foreground: oklch(0.145 0 0);
+	/* Tooltips float above cards, which share the page background, so they get their own surface
+	   instead of `--background`: in dark mode it has to be darker than everything underneath to
+	   read as a separate layer, since the shadow alone doesn't separate it. */
+	--tooltip: oklch(1 0 0);
 	--primary: var(--brand);
 	--primary-foreground: oklch(0.985 0 0);
 	--secondary: oklch(0.97 0 0);
@@ -100,6 +104,7 @@
 	--card-foreground: oklch(0.985 0 0);
 	--popover: oklch(0.31 0 0);
 	--popover-foreground: oklch(0.985 0 0);
+	--tooltip: oklch(0.21 0 0);
 	--primary: var(--brand);
 	--primary-foreground: oklch(0.985 0 0);
 	--secondary: oklch(0.27 0 0);
@@ -146,6 +151,7 @@
 	--color-card-foreground: var(--card-foreground);
 	--color-popover: var(--popover);
 	--color-popover-foreground: var(--popover-foreground);
+	--color-tooltip: var(--tooltip);
 	--color-primary: var(--primary);
 	--color-primary-foreground: var(--primary-foreground);
 	--color-secondary: var(--secondary);

--- a/src/app.css
+++ b/src/app.css
@@ -207,4 +207,15 @@
 	.font-mono span.font-mono {
 		vertical-align: baseline;
 	}
+
+	/* Charts and tables run to the viewport edges on phones: cancels the horizontal padding the
+	   page layout applies below `sm` (see page.svelte) so only the surface's own internal padding
+	   is left, and drops the corner radius that would otherwise sit on the screen edge. The
+	   `:not()` guard stops a surface nested inside another one from bleeding twice. */
+	@media (width < 40rem) {
+		.full-bleed:not(.full-bleed *) {
+			margin-inline: calc(--spacing(6) * -1);
+			border-radius: 0;
+		}
+	}
 }

--- a/src/lib/components/cashflow-averages.svelte
+++ b/src/lib/components/cashflow-averages.svelte
@@ -21,16 +21,17 @@
 </script>
 
 <Tabs.Root value="six-months">
-	<nav class="flex items-center justify-between space-x-2">
-		<SectionTitle {title} />
-
-		<Tabs.List aria-label={m.period_tabs_label({ section: title })}>
+	<SectionTitle {title}>
+		<Tabs.List
+			class="w-full max-sm:mb-1.5 sm:w-fit"
+			aria-label={m.period_tabs_label({ section: title })}
+		>
 			<Tabs.Trigger value="three-months">{m.period_3m_label()}</Tabs.Trigger>
 			<Tabs.Trigger value="six-months">{m.period_6m_label()}</Tabs.Trigger>
 			<Tabs.Trigger value="year-to-date">{m.period_ytd_label()}</Tabs.Trigger>
 			<Tabs.Trigger value="one-year">{m.period_1y_label()}</Tabs.Trigger>
 		</Tabs.List>
-	</nav>
+	</SectionTitle>
 
 	<Tabs.Content value="three-months">
 		<div class="grid gap-2 lg:grid-cols-[1.3fr_1fr_1fr]">

--- a/src/lib/components/filter-bar.svelte
+++ b/src/lib/components/filter-bar.svelte
@@ -83,7 +83,7 @@
 	});
 </script>
 
-<div class="flex flex-col gap-2 sm:flex-row sm:items-center">
+<div class="flex flex-col gap-2 max-sm:-mt-0.5 max-sm:mb-3.5 sm:flex-row sm:items-center">
 	<div class="relative flex-1">
 		<div class="text-muted-foreground pointer-events-none absolute top-1/2 left-3 -translate-y-1/2">
 			{#if isLoading}

--- a/src/lib/components/import-sessions-table.svelte
+++ b/src/lib/components/import-sessions-table.svelte
@@ -148,7 +148,9 @@
 					class={row.status === ImportSessionsStatusOptions.rolled_back ? 'bg-muted/30' : ''}
 				>
 					<Table.Cell>
-						<span class="text-foreground/90 text-sm font-medium">{row.label}</span>
+						<span class="cell-truncate text-foreground/90 text-sm font-medium" title={row.label}
+							>{row.label}</span
+						>
 					</Table.Cell>
 					<Table.Cell>
 						<Badge variant={statusVariants[row.status]}>{statusLabels[row.status]()}</Badge>

--- a/src/lib/components/import-sessions-table.svelte
+++ b/src/lib/components/import-sessions-table.svelte
@@ -85,7 +85,7 @@
 	);
 </script>
 
-<div class="bg-background overflow-hidden rounded-sm shadow-md">
+<div class="full-bleed bg-background overflow-hidden rounded-sm shadow-md">
 	<Table.Root>
 		<Table.Header>
 			<Table.Row>

--- a/src/lib/components/page.svelte
+++ b/src/lib/components/page.svelte
@@ -31,8 +31,11 @@
 <!-- iOS Safari tints the strip behind the status bar with the background of a sticky or fixed
      element near the viewport edge, so this row has to stay pinned there on mobile or the strip
      falls back to the body's color. It sits outside <header> because a sticky element can't
-     travel past its own parent's box, and the header ends well before the page does. -->
-<div class="bg-muted sticky top-0 z-10 md:static">
+     travel past its own parent's box, and the header ends well before the page does.
+     The stacking is dropped at `md`: a flex item's z-index applies even while it's static, so
+     `z-10` would tie with the fixed sidebar's own `z-10` and win on DOM order, painting over the
+     sidebar wherever the two overlap - which is anywhere the page scrolls horizontally. -->
+<div class="bg-muted sticky top-0 z-10 md:static md:z-auto">
 	<div class="flex h-12 items-center gap-2 px-4">
 		<Sidebar.Trigger class="-ml-1" />
 		<Separator orientation="vertical" class="mr-2 data-[orientation=vertical]:h-4" />

--- a/src/lib/components/page.svelte
+++ b/src/lib/components/page.svelte
@@ -36,17 +36,25 @@
 	<div class="flex h-12 items-center gap-2 px-4">
 		<Sidebar.Trigger class="-ml-1" />
 		<Separator orientation="vertical" class="mr-2 data-[orientation=vertical]:h-4" />
-		<Breadcrumb.Root>
-			<Breadcrumb.List>
+		<Breadcrumb.Root class="min-w-0 overflow-hidden">
+			<!-- The trail has to stay on a single line: wrapping pushes the first crumb under the phone's
+			     status bar. The section and the current page are never allowed to shrink, so any overflow
+			     is absorbed by the crumbs in between - in practice the entity name, which is the only
+			     segment of arbitrary length. -->
+			<Breadcrumb.List class="flex-nowrap">
 				{#each trail as crumb, index (index)}
 					{#if index > 0}
-						<Breadcrumb.Separator />
+						<Breadcrumb.Separator class="shrink-0" />
 					{/if}
-					<Breadcrumb.Item>
+					<Breadcrumb.Item
+						class={index === 0 || index === trail.length - 1 ? 'shrink-0' : 'min-w-0'}
+					>
 						{#if crumb.href}
-							<Breadcrumb.Link href={crumb.href}>{crumb.label}</Breadcrumb.Link>
+							<Breadcrumb.Link href={crumb.href} title={crumb.label} class="truncate"
+								>{crumb.label}</Breadcrumb.Link
+							>
 						{:else}
-							<Breadcrumb.Page>{crumb.label}</Breadcrumb.Page>
+							<Breadcrumb.Page title={crumb.label}>{crumb.label}</Breadcrumb.Page>
 						{/if}
 					</Breadcrumb.Item>
 				{/each}

--- a/src/lib/components/period-tabs.svelte
+++ b/src/lib/components/period-tabs.svelte
@@ -47,8 +47,8 @@
 	let { value = $bindable(), label }: { value: PeriodKey; label: string } = $props();
 </script>
 
-<Tabs.Root bind:value>
-	<Tabs.List aria-label={label}>
+<Tabs.Root bind:value class="w-full max-sm:mb-1.5 sm:w-fit">
+	<Tabs.List class="w-full sm:w-fit" aria-label={label}>
 		<Tabs.Trigger value="3m">{m.period_3m_label()}</Tabs.Trigger>
 		<Tabs.Trigger value="6m">{m.period_6m_label()}</Tabs.Trigger>
 		<Tabs.Trigger value="ytd">{m.period_ytd_label()}</Tabs.Trigger>

--- a/src/lib/components/positions-table.svelte
+++ b/src/lib/components/positions-table.svelte
@@ -62,7 +62,7 @@
 	});
 </script>
 
-<div class="bg-background overflow-hidden rounded-sm shadow-md">
+<div class="full-bleed bg-background overflow-hidden rounded-sm shadow-md">
 	<Table.Root>
 		<Table.Header>
 			<Table.Row>

--- a/src/lib/components/positions-table.svelte
+++ b/src/lib/components/positions-table.svelte
@@ -5,7 +5,6 @@
 	import NumberDisplay from '$lib/components/number.svelte';
 	import * as Table from '$lib/components/ui/table/index';
 	import { getExchangeRatesContext } from '$lib/exchange-rates.svelte';
-	import { getFormattingLocale } from '$lib/interface-preferences.svelte';
 	import { m } from '$lib/paraglide/messages';
 	import {
 		formatSecurityQuantity,
@@ -54,12 +53,6 @@
 	let { rows, entity, sortState, onSort }: Props = $props();
 
 	const fx = getExchangeRatesContext();
-	const dateFormatter = new Intl.DateTimeFormat(getFormattingLocale(), {
-		year: 'numeric',
-		month: 'short',
-		day: 'numeric',
-		timeZone: 'UTC'
-	});
 </script>
 
 <div class="full-bleed bg-background overflow-hidden rounded-sm shadow-md">
@@ -176,7 +169,8 @@
 						<Table.Cell>
 							<Link
 								href={resolve(`/securities/${row.id}`)}
-								class="text-foreground/90 text-sm font-medium"
+								title={row.name}
+								class="cell-truncate text-foreground/90 text-sm font-medium"
 							>
 								{row.name}
 							</Link>
@@ -189,11 +183,12 @@
 							{/if}
 						</Table.Cell>
 						<Table.Cell class="text-foreground/80 max-w-80 text-sm">
-							<div class="flex flex-wrap gap-x-1.5 gap-y-0.5">
+							<div class="flex flex-wrap gap-x-1.5 gap-y-0.5 max-sm:max-w-[18ch]">
 								{#each row.accounts as account (account.id)}
 									<Link
 										href={resolve(`/accounts/${account.id}`)}
-										class="text-foreground/80 text-sm"
+										title={account.name}
+										class="cell-truncate text-foreground/80 text-sm"
 									>
 										{account.name}
 									</Link>
@@ -204,14 +199,15 @@
 						<Table.Cell
 							class="text-muted-foreground font-mono whitespace-nowrap uppercase tabular-nums"
 						>
-							{dateFormatter.format(new Date(row.asOf))}
+							{new Date(row.asOf).toISOString().slice(0, 10)}
 						</Table.Cell>
 						<Table.Cell>
 							<Link
 								href={entity === 'account'
 									? resolve(`/accounts/${row.entityId}`)
 									: resolve(`/securities/${row.entityId}`)}
-								class="text-foreground/90 text-sm font-medium"
+								title={row.entityName}
+								class="cell-truncate text-foreground/90 text-sm font-medium"
 							>
 								{row.entityName}
 							</Link>

--- a/src/lib/components/record-link.svelte
+++ b/src/lib/components/record-link.svelte
@@ -32,7 +32,7 @@
 </script>
 
 <div class={'flex items-center gap-2 ' + wrapperClass}>
-	<Link {href} class={className}>{name}</Link>
+	<Link {href} title={name} class={className}>{name}</Link>
 	{#if isShared}
 		<SharedIndicator label={sharedLabel} />
 	{/if}

--- a/src/lib/components/section-title.svelte
+++ b/src/lib/components/section-title.svelte
@@ -4,8 +4,17 @@
 	let { title, children }: { title: string; children?: Snippet } = $props();
 </script>
 
-<div class="flex h-7 w-full items-center justify-between gap-2">
-	<h2 class="text-muted-foreground font-mono font-normal tracking-widest uppercase">
+<!-- A control that declares `w-full` below `sm` (the period tabs) drops onto its own row under the
+     title on phones, where the title and seven segments can't share a line. Controls that still fit
+     inline - links, short tab lists - stay on the title's row. Above `sm` nothing ever wraps.
+     The visual reference for stacked spacing is a title-only section, where the title's centered
+     28px box plus the section's 8px rhythm read as ~14px of air above the content. The 12px row
+     gap (plus ~2px glyph slack; `leading-none` strips the rest) hits that same ~14px above the
+     stacked control, and the control's own `max-sm` bottom margin hits it below. -->
+<div
+	class="flex min-h-7 w-full flex-wrap items-center justify-between gap-x-2 gap-y-3 sm:flex-nowrap"
+>
+	<h2 class="text-muted-foreground font-mono leading-none font-normal tracking-widest uppercase">
 		{title}
 	</h2>
 	{@render children?.()}

--- a/src/lib/components/section.svelte
+++ b/src/lib/components/section.svelte
@@ -4,6 +4,15 @@
 	let { children }: { children: Snippet } = $props();
 </script>
 
+<!-- Children sit on an 8px rhythm. A section title reads as ~14px of air below it because its
+     centered 28px box leaves glyph slack; solid-surface children - filter bars, summary card grids,
+     selection bars - have none, so each one followed by a sibling sets its own `max-sm` bottom
+     margin to reach that same ~14px on phones.
+     The value depends on how the parent separates its children. `space-y-*` compiles to a
+     `margin-block-end` on the child itself inside a zero-specificity `:where()`, so a margin
+     utility REPLACES the 8px rather than adding to it and must carry the full `max-sm:mb-3.5`.
+     A `gap-*` parent - the section title's flex row, `Tabs.Root` - leaves the child's margin
+     intact and adds to it, so `max-sm:mb-1.5` is enough there. Above `sm` neither applies. -->
 <section class="mx-auto flex w-full flex-col space-y-2">
 	{@render children?.()}
 </section>

--- a/src/lib/components/time-series-chart.svelte
+++ b/src/lib/components/time-series-chart.svelte
@@ -12,6 +12,8 @@
 	import { axisTicks } from '$lib/components/ui/chart/chart-utils.js';
 	import * as Chart from '$lib/components/ui/chart/index.js';
 	import Skeleton from '$lib/components/ui/skeleton/skeleton.svelte';
+	import { IsMobile } from '$lib/hooks/is-mobile.svelte.js';
+	import { getFormattingLocale } from '$lib/interface-preferences.svelte';
 	import { m } from '$lib/paraglide/messages';
 
 	type SeriesDef = {
@@ -62,6 +64,9 @@
 	const lastRow = $derived(windowedRows.at(-1) ?? null);
 	const isMultiSeries = $derived(series.length > 1);
 	const hasLegend = $derived(showLegend ?? isMultiSeries);
+
+	// Tracks the `sm` breakpoint, below which the chart runs edge to edge (see `.full-bleed`)
+	const isNarrowViewport = new IsMobile(640);
 
 	// The legend overlays the plot from the top and wraps within the container width, so
 	// the chart's top padding tracks its measured height to keep it clear of the marks
@@ -193,6 +198,34 @@
 		const widest = labels.reduce((width, label) => Math.max(width, textWidthMono(label)), 0);
 		return Math.max(48, Math.ceil(widest) + 16);
 	});
+
+	// Y labels overlay the plot on phones, so they trade precision for width: $200,000 becomes
+	// $200K. A unit only applies ten times above its own size, which keeps every label at two
+	// significant digits ($1,860 stays spelled out instead of collapsing to $2K).
+	function formatCompactAxisValue(value: number) {
+		const magnitude = Math.abs(value);
+		const unit =
+			magnitude >= 1e10
+				? { divisor: 1e9, suffix: 'B' }
+				: magnitude >= 1e7
+					? { divisor: 1e6, suffix: 'M' }
+					: magnitude >= 1e4
+						? { divisor: 1e3, suffix: 'K' }
+						: null;
+		if (!unit) return formatAxisValue(value);
+		// The suffix goes after the last digit rather than at the end of the string, so currencies
+		// formatted with a trailing code ("1,234 USDT") keep the code in place
+		return formatAxisValue(value / unit.divisor).replace(/(\d)(?=\D*$)/, `$1${unit.suffix}`);
+	}
+
+	// Phones can't fit the ISO x labels, so they get the short month and apostrophe year the
+	// cashflow chart uses ("Jul '26")
+	const formatNarrowDate = $derived.by(() => {
+		const locale = getFormattingLocale();
+		const month = new Intl.DateTimeFormat(locale, { month: 'short', timeZone: 'UTC' });
+		const year = new Intl.DateTimeFormat(locale, { year: '2-digit', timeZone: 'UTC' });
+		return (date: Date) => `${month.format(date)} '${year.format(date)}`;
+	});
 </script>
 
 <svelte:window onpointerup={endComparison} onpointercancel={endComparison} />
@@ -201,18 +234,18 @@
 	<PeriodTabs bind:value={period} label={m.period_tabs_label({ section: title })} />
 </SectionTitle>
 {#if isLoading}
-	<Skeleton class="h-[30vh] min-h-96" showSpinner />
+	<Skeleton class="full-bleed h-[30vh] min-h-96" showSpinner />
 {:else if rows.length < 2}
 	<div class="h-[30vh] min-h-96">
-		<Empty class="h-full">{emptyMessage}</Empty>
+		<Empty class="full-bleed h-full">{emptyMessage}</Empty>
 	</div>
 {:else if windowedRows.length < 2}
 	<div class="h-[30vh] min-h-96">
-		<Empty class="h-full">{m.chart_period_empty()}</Empty>
+		<Empty class="full-bleed h-full">{m.chart_period_empty()}</Empty>
 	</div>
 {:else}
 	<div
-		class="bg-background overflow-visible rounded-sm shadow-md"
+		class="full-bleed bg-background overflow-visible rounded-sm shadow-md"
 		data-chart-period={period}
 		data-chart-points={windowedRows.length}
 		data-chart-start={firstRow?.date.toISOString().slice(0, 10)}
@@ -269,9 +302,11 @@
 						yDomain={yDomain ?? undefined}
 						padding={{
 							top: hasLegend ? legendHeight + 16 : 16,
-							right: 48,
+							// Phones drop both gutters to a hairline inset: the y labels move inside the plot
+							// so the marks can run the full width of the screen
+							right: isNarrowViewport.current ? 12 : 48,
 							bottom: 24,
-							left: leftPadding
+							left: isNarrowViewport.current ? 12 : leftPadding
 						}}
 						series={series.map((s) => ({
 							key: s.key,
@@ -288,19 +323,49 @@
 							// for seconds when several charts mount at once.
 							spline: { curve: curveBumpX, opacity: 1, strokeWidth: 1.25, motion: 'none' },
 							xAxis: {
-								format: (v: Date) => v.toISOString().slice(0, 10),
-								ticks: 6,
+								format: (v: Date) =>
+									isNarrowViewport.current ? formatNarrowDate(v) : v.toISOString().slice(0, 10),
+								ticks: (scale) => {
+									const ticks = scale.ticks?.(isNarrowViewport.current ? 4 : 6) ?? [];
+									if (!isNarrowViewport.current) return ticks;
+									// Labels are centered on their tick and the plot now reaches the screen edges,
+									// so a tick sitting within half a label of an edge is dropped rather than clipped
+									const [rangeStart, rangeEnd] = scale.range();
+									return ticks.filter((tick) => {
+										const x = scale(tick);
+										return x - rangeStart >= 24 && rangeEnd - x >= 24;
+									});
+								},
 								motion: 'none'
 							},
 							yAxis: {
 								motion: 'none',
-								format: (v: number) => formatAxisValue(v),
+								format: (v: number) =>
+									isNarrowViewport.current ? formatCompactAxisValue(v) : formatAxisValue(v),
 								ticks: (scale) => {
 									const [min, max] = scale.domain();
 									return axisTicks(min, max);
-								}
+								},
+								// Without a gutter to sit in, narrow labels overlay the plot: flush with its left
+								// edge, resting just above their own tick, with a background-colored halo so they
+								// stay legible where a line runs underneath
+								tickLabelProps: isNarrowViewport.current
+									? {
+											textAnchor: 'start',
+											verticalAnchor: 'end',
+											dx: 0,
+											dy: -4,
+											class: 'stroke-background! stroke-2 [paint-order:stroke]'
+										}
+									: undefined
 							},
-							grid: { x: true, y: true, xTicks: 6, yTicks: [0], motion: 'none' },
+							grid: {
+								x: true,
+								y: true,
+								xTicks: isNarrowViewport.current ? 4 : 6,
+								yTicks: [0],
+								motion: 'none'
+							},
 							highlight: { motion: 'none', points: { r: 3, opacity: 1 } }
 						}}
 					>

--- a/src/lib/components/time-series-chart.svelte
+++ b/src/lib/components/time-series-chart.svelte
@@ -65,7 +65,8 @@
 	const isMultiSeries = $derived(series.length > 1);
 	const hasLegend = $derived(showLegend ?? isMultiSeries);
 
-	// Tracks the `sm` breakpoint, below which the chart runs edge to edge (see `.full-bleed`)
+	// Tracks the `sm` breakpoint, below which the x-axis thins its ticks so the labels
+	// keep their distance on a phone-width plot
 	const isNarrowViewport = new IsMobile(640);
 
 	// The legend overlays the plot from the top and wraps within the container width, so
@@ -208,11 +209,7 @@
 		) satisfies Chart.ChartConfig
 	);
 
-	// Identity-stable: recomputes triggered by chart-context ticks (visibleKeys is rebuilt on
-	// every context change) must not hand the chart a fresh-but-equal array, or the domain prop
-	// re-renders the chart, which ticks the context again in a mount-time feedback loop.
-	let lastYDomain: [number, number] | null = null;
-	const yDomain = $derived.by(() => {
+	const yExtent = $derived.by(() => {
 		let min = Number.POSITIVE_INFINITY;
 		let max = Number.NEGATIVE_INFINITY;
 		for (const row of windowedRows) {
@@ -222,35 +219,25 @@
 				max = Math.max(max, s.value(row));
 			}
 		}
-		if (min > max) return (lastYDomain = null);
-		const range = max - min;
+		return min > max ? null : { min, max };
+	});
+
+	// Identity-stable: recomputes triggered by chart-context ticks (visibleKeys is rebuilt on
+	// every context change) must not hand the chart a fresh-but-equal array, or the domain prop
+	// re-renders the chart, which ticks the context again in a mount-time feedback loop.
+	let lastYDomain: [number, number] | null = null;
+	const yDomain = $derived.by(() => {
+		if (!yExtent) return (lastYDomain = null);
+		const range = yExtent.max - yExtent.min;
 		// NOTE: a flat series (min === max) needs a pad scaled to the value's own magnitude -
 		// a fixed pad works for money (thousands) but would swamp small units like exchange rates.
-		const pad = range > 0 ? range * 0.05 : Math.max(Math.abs(max) * 0.05, 0.01);
-		const next: [number, number] = [min - pad, max + pad];
+		const pad = range > 0 ? range * 0.05 : Math.max(Math.abs(yExtent.max) * 0.05, 0.01);
+		const next: [number, number] = [yExtent.min - pad, yExtent.max + pad];
 		if (lastYDomain && lastYDomain[0] === next[0] && lastYDomain[1] === next[1]) return lastYDomain;
 		return (lastYDomain = next);
 	});
 
-	let measureCanvas: HTMLCanvasElement | null = null;
-	function textWidthMono(text: string) {
-		if (typeof document === 'undefined') return text.length * 8;
-		if (!measureCanvas) measureCanvas = document.createElement('canvas');
-		const context = measureCanvas.getContext('2d');
-		if (!context) return text.length * 8;
-		context.font =
-			'12px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace';
-		return context.measureText(text).width;
-	}
-
-	const leftPadding = $derived.by(() => {
-		if (!yDomain) return 48;
-		const labels = axisTicks(yDomain[0], yDomain[1]).map((tick) => formatAxisValue(tick));
-		const widest = labels.reduce((width, label) => Math.max(width, textWidthMono(label)), 0);
-		return Math.max(48, Math.ceil(widest) + 16);
-	});
-
-	// Y labels overlay the plot on phones, so they trade precision for width: $200,000 becomes
+	// Y labels overlay the plot, so they trade precision for width: $200,000 becomes
 	// $200K. A unit only applies ten times above its own size, which keeps every label at two
 	// significant digits ($1,860 stays spelled out instead of collapsing to $2K).
 	function formatCompactAxisValue(value: number) {
@@ -269,14 +256,11 @@
 		return formatAxisValue(value / unit.divisor).replace(/(\d)(?=\D*$)/, `$1${unit.suffix}`);
 	}
 
-	// Phones can't fit the ISO x labels, so they get the short month and apostrophe year the
-	// cashflow chart uses ("Jul '26")
-	const formatNarrowDate = $derived.by(() => {
-		const locale = getFormattingLocale();
-		const month = new Intl.DateTimeFormat(locale, { month: 'short', timeZone: 'UTC' });
-		const year = new Intl.DateTimeFormat(locale, { year: '2-digit', timeZone: 'UTC' });
-		return (date: Date) => `${month.format(date)} '${year.format(date)}`;
-	});
+	// A tick label reads against its neighbors - a month repeated across ticks says nothing, and
+	// so does a year repeated on every label - but the axis formats one tick at a time, so the
+	// labels are built for the whole tick list as it is handed over and looked up per tick here
+	// eslint-disable-next-line svelte/prefer-svelte-reactivity -- lookup cache written during chart render, never read reactively
+	const xTickLabels = new Map<number, string>();
 </script>
 
 <svelte:window onpointerup={onWindowPointerUp} onpointercancel={onWindowPointerCancel} />
@@ -379,11 +363,12 @@
 						yDomain={yDomain ?? undefined}
 						padding={{
 							top: hasLegend ? legendHeight + 16 : 16,
-							// Phones drop both gutters to a hairline inset: the y labels move inside the plot
-							// so the marks can run the full width of the screen
-							right: isNarrowViewport.current ? 12 : 48,
+							// Both gutters are a hairline inset matching the tables' px-4 cell padding, so
+							// the overlaid y labels align with first-column text while the marks still run
+							// nearly the full width of the card
+							right: 16,
 							bottom: 24,
-							left: isNarrowViewport.current ? 12 : leftPadding
+							left: 16
 						}}
 						series={series.map((s) => ({
 							key: s.key,
@@ -400,47 +385,77 @@
 							// for seconds when several charts mount at once.
 							spline: { curve: curveBumpX, opacity: 1, strokeWidth: 1.25, motion: 'none' },
 							xAxis: {
-								format: (v: Date) =>
-									isNarrowViewport.current ? formatNarrowDate(v) : v.toISOString().slice(0, 10),
+								format: (v: Date) => xTickLabels.get(+v) ?? '',
 								ticks: (scale) => {
-									const ticks = scale.ticks?.(isNarrowViewport.current ? 4 : 6) ?? [];
-									if (!isNarrowViewport.current) return ticks;
-									// Labels are centered on their tick and the plot now reaches the screen edges,
-									// so a tick sitting within half a label of an edge is dropped rather than clipped
+									let ticks: Date[] = scale.ticks?.(isNarrowViewport.current ? 4 : 6) ?? [];
+									// Labels are centered on their tick and the plot reaches the card's edges, so a
+									// tick sitting within half a label of an edge is dropped rather than clipped
 									const [rangeStart, rangeEnd] = scale.range();
-									return ticks.filter((tick) => {
+									ticks = ticks.filter((tick) => {
 										const x = scale(tick);
 										return x - rangeStart >= 24 && rangeEnd - x >= 24;
 									});
+									// Ticks closer together than a month would repeat the same month name, so the
+									// whole axis drops to days once any two neighbors share one ("Jul 14"). The
+									// year is written the way the cashflow chart writes it, on the first label and
+									// on every tick that opens a new one ("Jul 14 '26")
+									const sharesMonth = ticks.some(
+										(tick, index) =>
+											index > 0 &&
+											tick.toISOString().slice(0, 7) === ticks[index - 1].toISOString().slice(0, 7)
+									);
+									const locale = getFormattingLocale();
+									const date = new Intl.DateTimeFormat(locale, {
+										month: 'short',
+										day: sharesMonth ? 'numeric' : undefined,
+										timeZone: 'UTC'
+									});
+									const year = new Intl.DateTimeFormat(locale, {
+										year: '2-digit',
+										timeZone: 'UTC'
+									});
+									xTickLabels.clear();
+									for (const [index, tick] of ticks.entries()) {
+										const previous = ticks[index - 1];
+										const opensYear =
+											!previous ||
+											previous.toISOString().slice(0, 4) !== tick.toISOString().slice(0, 4);
+										xTickLabels.set(
+											+tick,
+											opensYear ? `${date.format(tick)} '${year.format(tick)}` : date.format(tick)
+										);
+									}
+									return ticks;
 								},
 								motion: 'none'
 							},
 							yAxis: {
 								motion: 'none',
-								format: (v: number) =>
-									isNarrowViewport.current ? formatCompactAxisValue(v) : formatAxisValue(v),
+								format: formatCompactAxisValue,
 								ticks: (scale) => {
 									const [min, max] = scale.domain();
 									return axisTicks(min, max);
 								},
-								// Without a gutter to sit in, narrow labels overlay the plot: flush with its left
+								// Without a gutter to sit in, the labels overlay the plot: flush with its left
 								// edge, resting just above their own tick, with a background-colored halo so they
 								// stay legible where a line runs underneath
-								tickLabelProps: isNarrowViewport.current
-									? {
-											textAnchor: 'start',
-											verticalAnchor: 'end',
-											dx: 0,
-											dy: -4,
-											class: 'stroke-background! stroke-2 [paint-order:stroke]'
-										}
-									: undefined
+								tickLabelProps: {
+									textAnchor: 'start',
+									verticalAnchor: 'end',
+									dx: 0,
+									dy: -4,
+									class: 'stroke-background! stroke-2 [paint-order:stroke]'
+								}
 							},
 							grid: {
 								x: true,
-								y: true,
-								xTicks: isNarrowViewport.current ? 4 : 6,
+								// The horizontal rule marks where the series crosses between positive and
+								// negative. With every value on one side of zero there is no crossing to mark,
+								// and the y scale extrapolates past its domain, so the rule would still be
+								// drawn - stranded under the marks by the domain's padding, or off-plot
+								y: yExtent !== null && yExtent.min < 0 && yExtent.max > 0,
 								yTicks: [0],
+								xTicks: isNarrowViewport.current ? 4 : 6,
 								motion: 'none'
 							},
 							highlight: { motion: 'none', points: { r: 3, opacity: 1 } }

--- a/src/lib/components/time-series-chart.svelte
+++ b/src/lib/components/time-series-chart.svelte
@@ -120,6 +120,57 @@
 		comparisonCurrent = null;
 	}
 
+	// Touch has no hover to drive layerchart's tooltip: a finger that lands on the chart on its way
+	// to scrolling the page opens one, and the pointercancel the scroll begins with leaves it
+	// stranded on screen. Touch pointer events are stopped before layerchart sees them (see the plot
+	// wrapper below) and the tooltip is driven from the gesture instead - a tap pins it to the tapped
+	// point, a horizontal drag scrubs it along the x-axis and pins it where the finger lifts, and any
+	// other touch, on this chart or elsewhere, clears it.
+	const TAP_SLOP_PX = 10;
+	const SCRUB_DIRECTION_PX = 8;
+	let tapOrigin: { x: number; y: number } | null = null;
+	let isScrubbing = false;
+
+	// The gesture's axis is decided once, off its first few pixels of movement: mostly horizontal
+	// scrubs, mostly vertical is the page scroll the plot's `touch-action: pan-y` leaves to the
+	// browser (dropping the origin so the lift neither pins nor counts as a tap). Deciding once
+	// means vertical wobble can't cancel a scrub halfway through.
+	function trackScrub(event: PointerEvent) {
+		if (!tapOrigin) return;
+		if (!isScrubbing) {
+			const dx = event.clientX - tapOrigin.x;
+			const dy = event.clientY - tapOrigin.y;
+			if (Math.hypot(dx, dy) < SCRUB_DIRECTION_PX) return;
+			if (Math.abs(dy) >= Math.abs(dx)) {
+				tapOrigin = null;
+				return;
+			}
+			isScrubbing = true;
+		}
+		chartContext?.tooltip.show(event);
+	}
+
+	function onWindowPointerUp(event: PointerEvent) {
+		endComparison();
+		if (event.pointerType === 'mouse') return;
+		const origin = tapOrigin;
+		const wasScrubbing = isScrubbing;
+		tapOrigin = null;
+		isScrubbing = false;
+		const isTap =
+			origin !== null &&
+			Math.hypot(event.clientX - origin.x, event.clientY - origin.y) <= TAP_SLOP_PX;
+		if (wasScrubbing || isTap) chartContext?.tooltip.show(event);
+		else chartContext?.tooltip.hide();
+	}
+
+	function onWindowPointerCancel() {
+		endComparison();
+		tapOrigin = null;
+		isScrubbing = false;
+		chartContext?.tooltip.hide();
+	}
+
 	// Legend toggling narrows the chart's visible series; the compare tooltip and y-domain follow it
 	const visibleKeys = $derived(
 		new Set(chartContext?.series.visibleSeries.map((s) => s.key) ?? series.map((s) => s.key))
@@ -228,7 +279,7 @@
 	});
 </script>
 
-<svelte:window onpointerup={endComparison} onpointercancel={endComparison} />
+<svelte:window onpointerup={onWindowPointerUp} onpointercancel={onWindowPointerCancel} />
 
 <SectionTitle {title}>
 	<PeriodTabs bind:value={period} label={m.period_tabs_label({ section: title })} />
@@ -259,6 +310,16 @@
 			role={hasLegend ? undefined : 'img'}
 			aria-label={hasLegend ? undefined : series[0].label}
 			onpointerdown={(event) => {
+				if (event.pointerType !== 'mouse') {
+					// Comparison drag stays mouse-only - on touch that gesture is the scrub - so a touch
+					// only ever records where it started. Touches landing outside the plot can't be
+					// resolved to a data point, so they start neither a tap nor a scrub.
+					const isInPlot =
+						event.target instanceof Element && event.target.closest('.lc-root-container') !== null;
+					tapOrigin = isInPlot ? { x: event.clientX, y: event.clientY } : null;
+					isScrubbing = false;
+					return;
+				}
 				if (event.button !== 0) return;
 				dragging = true;
 				comparisonAnchor = hovered;
@@ -266,7 +327,23 @@
 			}}
 		>
 			<div
-				class="relative w-full"
+				class="relative w-full touch-pan-y"
+				{@attach (node) => {
+					// layerchart opens its tooltip on pointerenter/pointermove and clears it on pointerleave,
+					// none of which describe a touch gesture. Touch pointers are stopped on the way down so
+					// they never reach layerchart's tooltip surface, leaving the tooltip under the explicit
+					// control of the gesture handling above; mouse pointers pass through untouched.
+					const stopTouchPointers = (event: Event) => {
+						if (!(event instanceof PointerEvent) || event.pointerType === 'mouse') return;
+						event.stopPropagation();
+						if (event.type === 'pointermove') trackScrub(event);
+					};
+					const names = ['pointerenter', 'pointermove', 'pointerleave'];
+					for (const name of names) node.addEventListener(name, stopTouchPointers, true);
+					return () => {
+						for (const name of names) node.removeEventListener(name, stopTouchPointers, true);
+					};
+				}}
 				{@attach (node) => {
 					let lastLayoutAt = Number.NEGATIVE_INFINITY;
 					let timer = 0;

--- a/src/lib/components/ui/chart/chart-container.svelte
+++ b/src/lib/components/ui/chart/chart-container.svelte
@@ -61,6 +61,9 @@
 		'[&_.lc-legend-swatch-button]:items-center [&_.lc-legend-swatch-button]:gap-1.5',
 		'[&_.lc-legend-swatch-group]:items-center [&_.lc-legend-swatch-group]:gap-x-4 [&_.lc-legend-swatch-group]:gap-y-1',
 		'[&_.lc-legend-swatch]:size-2.5 [&_.lc-legend-swatch]:rounded-xl',
+		// Below `sm` the chart runs edge to edge (see `.full-bleed`), which would leave the outer
+		// legend items flush against the viewport; keep them inset by the same hairline the plot uses
+		'max-sm:[&_.lc-legend-container]:px-3',
 
 		// Labels
 		'[&_.lc-labels-text:not([fill])]:fill-foreground [&_text]:stroke-transparent',

--- a/src/lib/components/ui/chart/chart-tooltip.svelte
+++ b/src/lib/components/ui/chart/chart-tooltip.svelte
@@ -43,7 +43,7 @@ highlighted point's crosshair and the default `contained="container"` flips it a
 <TooltipPrimitive.Root variant="none" motion="none" x="data" xOffset={12} y={chart.padding.top}>
 	<div
 		class={cn(
-			'bg-background grid min-w-[9rem] items-start gap-1.5 rounded-lg px-2.5 py-1.5 shadow-xl',
+			'bg-tooltip grid min-w-[9rem] items-start gap-1.5 rounded-lg px-2.5 py-1.5 shadow-xl',
 			className
 		)}
 		{...restProps}

--- a/src/lib/components/ui/table/sortable-head.svelte
+++ b/src/lib/components/ui/table/sortable-head.svelte
@@ -35,7 +35,7 @@
 	bind:this={ref}
 	data-slot="table-head"
 	class={cn(
-		'text-muted-foreground h-10 bg-clip-padding px-4 py-2 text-left align-middle text-xs font-normal whitespace-nowrap [&:has([role=checkbox])]:pr-0',
+		'text-muted-foreground h-10 bg-clip-padding px-4 py-2 text-left align-middle text-xs font-normal whitespace-nowrap max-sm:not-first:pl-2.5 max-sm:not-last:pr-2.5 [&:has([role=checkbox])]:pr-0',
 		className
 	)}
 	aria-sort={ariaSort}

--- a/src/lib/components/ui/table/table-cell.svelte
+++ b/src/lib/components/ui/table/table-cell.svelte
@@ -11,10 +11,17 @@
 	}: WithElementRef<HTMLTdAttributes> = $props();
 </script>
 
+<!-- Below `sm` a cell never wraps - on a phone a wrapped value turns one row into several lines -
+     and the padding between columns halves so the narrow width goes to content instead of gutters.
+     The outer edges keep the 16px inset the charts align to, so only the inner gutters tighten.
+     Cells holding free text pair this with `cell-truncate` (see app.css) to cap their width. -->
 <td
 	bind:this={ref}
 	data-slot="table-cell"
-	class={cn('bg-clip-padding px-4 py-2 align-middle [&:has([role=checkbox])]:pr-0', className)}
+	class={cn(
+		'bg-clip-padding px-4 py-2 align-middle max-sm:whitespace-nowrap max-sm:not-first:pl-2.5 max-sm:not-last:pr-2.5 [&:has([role=checkbox])]:pr-0',
+		className
+	)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/src/lib/components/ui/table/table-head.svelte
+++ b/src/lib/components/ui/table/table-head.svelte
@@ -15,7 +15,7 @@
 	bind:this={ref}
 	data-slot="table-head"
 	class={cn(
-		'text-muted-foreground h-10 bg-clip-padding px-4 py-2 text-left align-middle text-xs font-normal whitespace-nowrap [&:has([role=checkbox])]:pr-0',
+		'text-muted-foreground h-10 bg-clip-padding px-4 py-2 text-left align-middle text-xs font-normal whitespace-nowrap max-sm:not-first:pl-2.5 max-sm:not-last:pr-2.5 [&:has([role=checkbox])]:pr-0',
 		className
 	)}
 	{...restProps}

--- a/src/lib/components/ui/tooltip/index.ts
+++ b/src/lib/components/ui/tooltip/index.ts
@@ -2,8 +2,8 @@ import { Tooltip as TooltipPrimitive } from 'bits-ui';
 
 import Content from './tooltip-content.svelte';
 import Trigger from './tooltip-trigger.svelte';
+import Root from './tooltip.svelte';
 
-const Root = TooltipPrimitive.Root;
 const Provider = TooltipPrimitive.Provider;
 const Portal = TooltipPrimitive.Portal;
 

--- a/src/lib/components/ui/tooltip/tooltip-content.svelte
+++ b/src/lib/components/ui/tooltip/tooltip-content.svelte
@@ -23,7 +23,7 @@
 		{sideOffset}
 		{side}
 		class={cn(
-			'animate-in bg-background text-foreground fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 z-50 w-fit origin-(--bits-tooltip-content-transform-origin) rounded-lg px-2.5 py-1.5 shadow-xl',
+			'animate-in bg-tooltip text-foreground fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 z-50 w-fit origin-(--bits-tooltip-content-transform-origin) rounded-lg px-2.5 py-1.5 shadow-xl',
 			className
 		)}
 		{...restProps}
@@ -33,7 +33,7 @@
 			{#snippet child({ props })}
 				<div
 					class={cn(
-						'bg-background z-50 size-2.5 rotate-45 rounded-[2px]',
+						'bg-tooltip z-50 size-2.5 rotate-45 rounded-[2px]',
 						'data-[side=top]:translate-x-1/2 data-[side=top]:translate-y-[calc(-50%_+_2px)]',
 						'data-[side=bottom]:-translate-x-1/2 data-[side=bottom]:-translate-y-[calc(-50%_+_1px)]',
 						'data-[side=right]:translate-x-[calc(50%_+_2px)] data-[side=right]:translate-y-1/2',

--- a/src/lib/components/ui/tooltip/tooltip-trigger.svelte
+++ b/src/lib/components/ui/tooltip/tooltip-trigger.svelte
@@ -1,7 +1,20 @@
 <script lang="ts">
 	import { Tooltip as TooltipPrimitive } from 'bits-ui';
 
+	import { getTooltipTouchOpener } from './tooltip.svelte';
+
 	let { ref = $bindable(null), ...restProps }: TooltipPrimitive.TriggerProps = $props();
+
+	const openOnTouch = getTooltipTouchOpener();
 </script>
 
-<TooltipPrimitive.Trigger bind:ref data-slot="tooltip-trigger" {...restProps} />
+<TooltipPrimitive.Trigger
+	bind:ref
+	data-slot="tooltip-trigger"
+	onpointerup={(event) => {
+		// bits-ui only opens on pointer hover, which touch never produces; a completed tap is the
+		// equivalent deliberate gesture
+		if (event.pointerType !== 'mouse') openOnTouch();
+	}}
+	{...restProps}
+/>

--- a/src/lib/components/ui/tooltip/tooltip.svelte
+++ b/src/lib/components/ui/tooltip/tooltip.svelte
@@ -1,0 +1,32 @@
+<script lang="ts" module>
+	import { getContext, setContext } from 'svelte';
+
+	const TOOLTIP_TOUCH_KEY = Symbol('tooltip-touch');
+
+	export function getTooltipTouchOpener() {
+		return getContext<() => void>(TOOLTIP_TOUCH_KEY);
+	}
+</script>
+
+<script lang="ts">
+	import { Tooltip as TooltipPrimitive } from 'bits-ui';
+
+	let { open = $bindable(false), ...restProps }: TooltipPrimitive.RootProps = $props();
+
+	// A tap produces no pointer hover for bits-ui to open on, and the click it ends with would close
+	// whatever the trigger's focus did manage to open, so on touch the tooltip only flashes. The
+	// trigger opens this state directly instead (see tooltip-trigger.svelte); while a tap is what
+	// opened it, bits-ui's close-on-click is switched off so the same tap can't take it straight
+	// back, and the content's dismissible layer closes it when the next tap lands outside. A mouse
+	// click still closes the tooltip the way bits-ui intends.
+	let isOpenedByTouch = $state(false);
+	setContext(TOOLTIP_TOUCH_KEY, () => {
+		isOpenedByTouch = true;
+		open = true;
+	});
+	$effect(() => {
+		if (!open) isOpenedByTouch = false;
+	});
+</script>
+
+<TooltipPrimitive.Root bind:open disableCloseOnTriggerClick={isOpenedByTouch} {...restProps} />

--- a/src/routes/(app)/accounts/+page.svelte
+++ b/src/routes/(app)/accounts/+page.svelte
@@ -286,7 +286,7 @@
 								{option.empty}
 							</Empty>
 						{:else}
-							<div class="bg-background overflow-hidden rounded-sm shadow-md">
+							<div class="full-bleed bg-background overflow-hidden rounded-sm shadow-md">
 								<Table.Root>
 									<Table.Header>
 										<Table.Row>

--- a/src/routes/(app)/accounts/+page.svelte
+++ b/src/routes/(app)/accounts/+page.svelte
@@ -346,12 +346,14 @@
 														id={row.id}
 														name={row.name}
 														isShared={row.isShared}
-														class="text-foreground/90 text-sm font-medium"
+														class="cell-truncate text-foreground/90 text-sm font-medium"
 													/>
 												</Table.Cell>
 												<Table.Cell class="text-foreground/80 text-sm">
 													{#if row.institution}
-														{row.institution}
+														<span class="cell-truncate" title={row.institution}
+															>{row.institution}</span
+														>
 													{:else}
 														<span class="text-muted-foreground">~</span>
 													{/if}

--- a/src/routes/(app)/accounts/+page.svelte
+++ b/src/routes/(app)/accounts/+page.svelte
@@ -266,7 +266,7 @@
 							value: null,
 							isPartial: false
 						}}
-						<div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
+						<div class="grid grid-cols-1 gap-2 max-sm:mt-1.5 max-sm:mb-4 sm:grid-cols-2">
 							<KeyValue
 								title={m.accounts_summary_count_label()}
 								value={rowsForOption.length}

--- a/src/routes/(app)/accounts/[id]/+page.svelte
+++ b/src/routes/(app)/accounts/[id]/+page.svelte
@@ -516,7 +516,8 @@
 									{#if row.description}
 										<Link
 											href={resolve(`/trades/${row.id}`)}
-											class="text-foreground/90 text-sm font-medium"
+											title={row.description}
+											class="cell-truncate text-foreground/90 text-sm font-medium"
 										>
 											{row.description}
 										</Link>
@@ -530,12 +531,15 @@
 									{#if row.securityName && row.securityId}
 										<Link
 											href={resolve(`/securities/${row.securityId}`)}
-											class="text-foreground/80 text-sm"
+											title={row.securityName}
+											class="cell-truncate text-foreground/80 text-sm"
 										>
 											{row.securityName}
 										</Link>
 									{:else if row.securityName}
-										<span class="text-foreground/80 text-sm">{row.securityName}</span>
+										<span class="cell-truncate text-foreground/80 text-sm" title={row.securityName}
+											>{row.securityName}</span
+										>
 									{:else}
 										<span class="text-muted-foreground text-sm">~</span>
 									{/if}
@@ -627,7 +631,8 @@
 									{#if row.description}
 										<Link
 											href={resolve(`/transactions/${row.id}`)}
-											class="text-foreground/90 text-sm font-medium"
+											title={row.description}
+											class="cell-truncate text-foreground/90 text-sm font-medium"
 										>
 											{row.description}
 										</Link>
@@ -640,7 +645,7 @@
 								</Table.Cell>
 								<Table.Cell>
 									{#if row.labelChips.length}
-										<div class="flex flex-wrap gap-2">
+										<div class="flex flex-wrap gap-2 max-sm:max-w-[18ch]">
 											{#each row.labelChips as label (label.id)}
 												<span class={badgeVariants({ variant: 'outline' })}>{label.name}</span>
 											{/each}

--- a/src/routes/(app)/accounts/[id]/+page.svelte
+++ b/src/routes/(app)/accounts/[id]/+page.svelte
@@ -454,7 +454,7 @@
 			<Skeleton class="h-64" showSpinner />
 		{:else if positionsRows.length > 0}
 			<div
-				class="grid overflow-hidden rounded-sm shadow-md [&>div]:rounded-none [&>div]:shadow-none"
+				class="full-bleed grid overflow-hidden rounded-sm shadow-md [&>div]:rounded-none [&>div]:shadow-none"
 			>
 				<PositionsTable
 					rows={topPositionsRows}
@@ -486,7 +486,7 @@
 		{#if !loaded || samplesLoading || !account}
 			<Skeleton class="h-64" showSpinner />
 		{:else if tradeRows.length > 0}
-			<div class="bg-background overflow-hidden rounded-sm shadow-md">
+			<div class="full-bleed bg-background overflow-hidden rounded-sm shadow-md">
 				<Table.Root>
 					<Table.Header>
 						<Table.Row>
@@ -597,7 +597,7 @@
 		{#if !loaded || samplesLoading || !account}
 			<Skeleton class="h-64" showSpinner />
 		{:else if transactionRows.length > 0}
-			<div class="bg-background overflow-hidden rounded-sm shadow-md">
+			<div class="full-bleed bg-background overflow-hidden rounded-sm shadow-md">
 				<Table.Root>
 					<Table.Header>
 						<Table.Row>

--- a/src/routes/(app)/assets/+page.svelte
+++ b/src/routes/(app)/assets/+page.svelte
@@ -237,7 +237,7 @@
 								{option.empty}
 							</Empty>
 						{:else}
-							<div class="bg-background overflow-hidden rounded-sm shadow-md">
+							<div class="full-bleed bg-background overflow-hidden rounded-sm shadow-md">
 								<Table.Root>
 									<Table.Header>
 										<Table.Row>

--- a/src/routes/(app)/assets/+page.svelte
+++ b/src/routes/(app)/assets/+page.svelte
@@ -217,7 +217,7 @@
 							value: null,
 							isPartial: false
 						}}
-						<div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
+						<div class="grid grid-cols-1 gap-2 max-sm:mt-1.5 max-sm:mb-4 sm:grid-cols-2">
 							<KeyValue
 								title={m.sidebar_assets()}
 								value={rowsForOption.length}

--- a/src/routes/(app)/assets/+page.svelte
+++ b/src/routes/(app)/assets/+page.svelte
@@ -306,7 +306,7 @@
 														id={row.id}
 														name={row.name}
 														isShared={row.isShared}
-														class="text-foreground/90 text-sm font-medium"
+														class="cell-truncate text-foreground/90 text-sm font-medium"
 													/>
 												</Table.Cell>
 												<Table.Cell>

--- a/src/routes/(app)/big-picture/cashflow.svelte
+++ b/src/routes/(app)/big-picture/cashflow.svelte
@@ -6,17 +6,23 @@
 	import Currency from '$lib/components/currency.svelte';
 	import { Skeleton } from '$lib/components/ui/skeleton';
 	import * as Tooltip from '$lib/components/ui/tooltip';
+	import { IsMobile } from '$lib/hooks/is-mobile.svelte.js';
 	import { getFormattingLocale } from '$lib/interface-preferences.svelte';
 	import { m } from '$lib/paraglide/messages';
 
 	const cashflow = getCashflowContext();
 	const periods = $derived(cashflow.periods);
 
+	// Tracks the `sm` breakpoint, below which the chart runs edge to edge
+	const isNarrowViewport = new IsMobile(640);
+
 	let hoveredIndex = $state<number | null>(null);
 
 	const chartData = $derived.by(() => {
+		// Twelve columns share the viewport width, so phones get single-letter month names;
+		// the full month is still reachable through each column's label and tooltip
 		const monthFormatter = new Intl.DateTimeFormat(getFormattingLocale(), {
-			month: 'short',
+			month: isNarrowViewport.current ? 'narrow' : 'short',
 			timeZone: 'UTC'
 		});
 		const yearFormatter = new Intl.DateTimeFormat(getFormattingLocale(), {
@@ -110,7 +116,7 @@
 </script>
 
 {#if chartData.length > 0}
-	<div class="bg-background h-[30vh] min-h-[220px] overflow-hidden rounded shadow-md">
+	<div class="full-bleed bg-background h-[30vh] min-h-[220px] overflow-hidden rounded shadow-md">
 		<Tooltip.Provider>
 			<!-- Outer grid: one column per period -->
 			<div
@@ -253,5 +259,5 @@
 		</Tooltip.Provider>
 	</div>
 {:else if cashflow.isLoading}
-	<Skeleton class="h-[30vh] min-h-[220px]" showSpinner />
+	<Skeleton class="full-bleed h-[30vh] min-h-[220px]" showSpinner />
 {/if}

--- a/src/routes/(app)/currencies/+page.svelte
+++ b/src/routes/(app)/currencies/+page.svelte
@@ -131,7 +131,7 @@
 					{m.currencies_empty()}
 				</Empty>
 			{:else}
-				<div class="bg-background overflow-hidden rounded-sm shadow-md">
+				<div class="full-bleed bg-background overflow-hidden rounded-sm shadow-md">
 					<Table.Root>
 						<Table.Header>
 							<Table.Row>

--- a/src/routes/(app)/currencies/+page.svelte
+++ b/src/routes/(app)/currencies/+page.svelte
@@ -193,7 +193,7 @@
 									</Table.Cell>
 									<Table.Cell class="text-foreground/80 text-sm">
 										{#if row.name}
-											{row.name}
+											<span class="cell-truncate" title={row.name}>{row.name}</span>
 										{:else}
 											<span class="text-muted-foreground">~</span>
 										{/if}

--- a/src/routes/(app)/currencies/[id]/+page.svelte
+++ b/src/routes/(app)/currencies/[id]/+page.svelte
@@ -161,7 +161,7 @@
 			{#if sortedRows.length === 0}
 				<Empty>{m.currencies_no_quotes()}</Empty>
 			{:else}
-				<div class="bg-background overflow-hidden rounded-sm shadow-md">
+				<div class="full-bleed bg-background overflow-hidden rounded-sm shadow-md">
 					<Table.Root>
 						<Table.Header>
 							<Table.Row>

--- a/src/routes/(app)/currencies/[id]/+page.svelte
+++ b/src/routes/(app)/currencies/[id]/+page.svelte
@@ -148,7 +148,7 @@
 				<div
 					role="region"
 					aria-label={m.currencies_table_header_latest_quote()}
-					class="grid grid-cols-1 gap-2"
+					class="grid grid-cols-1 gap-2 max-sm:-mt-0.5 max-sm:mb-4"
 				>
 					<KeyValue
 						title={m.currencies_table_header_latest_quote()}

--- a/src/routes/(app)/portfolio/+page.svelte
+++ b/src/routes/(app)/portfolio/+page.svelte
@@ -343,13 +343,13 @@
 					</Tabs.List>
 				</SectionTitle>
 				{#if securitiesContext.isLoading}
-					<Skeleton class="h-[30vh] min-h-96" showSpinner />
+					<Skeleton class="full-bleed h-[30vh] min-h-96" showSpinner />
 				{:else if allocationRows.length === 0}
 					<div class="h-[30vh] min-h-96">
-						<Empty class="h-full">{m.allocation_empty()}</Empty>
+						<Empty class="full-bleed h-full">{m.allocation_empty()}</Empty>
 					</div>
 				{:else}
-					<div class="bg-background overflow-hidden rounded-sm shadow-md">
+					<div class="full-bleed bg-background overflow-hidden rounded-sm shadow-md">
 						<AllocationTreemap rows={allocationRows} mode={allocationMode} />
 					</div>
 				{/if}

--- a/src/routes/(app)/portfolio/+page.svelte
+++ b/src/routes/(app)/portfolio/+page.svelte
@@ -278,7 +278,7 @@
 			{#if rows.length === 0}
 				<Empty>{accountRows.length === 0 ? m.portfolio_empty() : m.portfolio_table_empty()}</Empty>
 			{:else}
-				<div class="grid grid-cols-1 gap-2 sm:grid-cols-3">
+				<div class="grid grid-cols-1 gap-2 max-sm:mb-4 sm:grid-cols-3">
 					<KeyValue
 						title={m.summary_net_gain_loss()}
 						value={gainLossTotal.total}

--- a/src/routes/(app)/securities/+page.svelte
+++ b/src/routes/(app)/securities/+page.svelte
@@ -42,7 +42,7 @@
 		{:else if securitiesContext.securities.length === 0}
 			<Empty>{m.securities_empty()}</Empty>
 		{:else}
-			<div class="bg-background overflow-hidden rounded-sm shadow-md">
+			<div class="full-bleed bg-background overflow-hidden rounded-sm shadow-md">
 				<Table.Root>
 					<Table.Header>
 						<Table.Row>

--- a/src/routes/(app)/securities/+page.svelte
+++ b/src/routes/(app)/securities/+page.svelte
@@ -72,7 +72,8 @@
 								<Table.Cell>
 									<Link
 										href={resolve(`/securities/${row.id}`)}
-										class="text-foreground/90 text-sm font-medium"
+										title={row.name}
+										class="cell-truncate text-foreground/90 text-sm font-medium"
 									>
 										{row.name}
 									</Link>

--- a/src/routes/(app)/securities/[id]/+page.svelte
+++ b/src/routes/(app)/securities/[id]/+page.svelte
@@ -142,7 +142,7 @@
 		<div
 			role="region"
 			aria-label={m.securities_section_positions()}
-			class="grid grid-cols-1 gap-2 sm:grid-cols-2"
+			class="grid grid-cols-1 gap-2 max-sm:-mt-0.5 max-sm:mb-4 sm:grid-cols-2"
 		>
 			<KeyValue
 				title={m.securities_summary_count_label()}

--- a/src/routes/(app)/settings/connections/+page.svelte
+++ b/src/routes/(app)/settings/connections/+page.svelte
@@ -219,7 +219,10 @@
 							syncingConnectionId === connection.id || unlinkingConnectionId === connection.id}
 						<Table.Row>
 							<Table.Cell>
-								<span class="text-foreground/90 text-sm font-medium">
+								<span
+									class="cell-truncate text-foreground/90 text-sm font-medium"
+									title={connection.institutionName || m.settings_connections_unnamed_institution()}
+								>
 									{connection.institutionName || m.settings_connections_unnamed_institution()}
 								</span>
 							</Table.Cell>

--- a/src/routes/(app)/settings/connections/+page.svelte
+++ b/src/routes/(app)/settings/connections/+page.svelte
@@ -188,7 +188,7 @@
 			{m.settings_connections_empty()}
 		</Empty>
 	{:else}
-		<div class="bg-background overflow-hidden rounded-sm shadow-md">
+		<div class="full-bleed bg-background overflow-hidden rounded-sm shadow-md">
 			<Table.Root>
 				<Table.Header>
 					<Table.Row>

--- a/src/routes/(app)/trades/trade-summary.svelte
+++ b/src/routes/(app)/trades/trade-summary.svelte
@@ -22,7 +22,7 @@
 <div
 	role="region"
 	aria-label={m.trades_summary_aria_label()}
-	class="grid grid-cols-1 gap-2 sm:grid-cols-2"
+	class="grid grid-cols-1 gap-2 max-sm:mb-4 sm:grid-cols-2"
 >
 	<KeyValue
 		title={m.trades_summary_count_label()}

--- a/src/routes/(app)/trades/trades-table.svelte
+++ b/src/routes/(app)/trades/trades-table.svelte
@@ -9,7 +9,6 @@
 	import * as Pagination from '$lib/components/ui/pagination/index';
 	import * as Table from '$lib/components/ui/table/index';
 	import { getExchangeRatesContext } from '$lib/exchange-rates.svelte';
-	import { getFormattingLocale } from '$lib/interface-preferences.svelte';
 	import { m } from '$lib/paraglide/messages';
 	import { formatSecurityQuantity } from '$lib/security-balance-values';
 	import { tradeTypeLabel } from '$lib/trade-display';
@@ -22,16 +21,6 @@
 		event.preventDefault();
 		const from = window.location.pathname + window.location.search;
 		await goto(resolve(`/trades/${id}?from=${encodeURIComponent(from)}`));
-	}
-
-	const dateFormatter = new Intl.DateTimeFormat(getFormattingLocale(), {
-		year: 'numeric',
-		month: 'short',
-		day: 'numeric',
-		timeZone: 'UTC'
-	});
-	function formatDate(date: Date) {
-		return dateFormatter.format(date);
 	}
 
 	function amountClass(value: number) {
@@ -88,14 +77,15 @@
 						<Table.Cell
 							class="text-muted-foreground font-mono whitespace-nowrap uppercase tabular-nums"
 						>
-							{formatDate(row.date)}
+							{row.date.toISOString().slice(0, 10)}
 						</Table.Cell>
 						<Table.Cell>
 							{#if row.description}
 								<Link
 									href="/trades/{row.id}"
 									onclick={(event) => openTrade(event, row.id)}
-									class="text-foreground/90 text-sm font-medium"
+									title={row.description}
+									class="cell-truncate text-foreground/90 text-sm font-medium"
 								>
 									{row.description}
 								</Link>
@@ -111,12 +101,15 @@
 							{#if row.securityName && row.securityId}
 								<Link
 									href={resolve(`/securities/${row.securityId}`)}
-									class="text-foreground/80 text-sm"
+									title={row.securityName}
+									class="cell-truncate text-foreground/80 text-sm"
 								>
 									{row.securityName}
 								</Link>
 							{:else if row.securityName}
-								<span class="text-foreground/80 text-sm">{row.securityName}</span>
+								<span class="cell-truncate text-foreground/80 text-sm" title={row.securityName}
+									>{row.securityName}</span
+								>
 							{:else}
 								<span class="text-muted-foreground text-sm">~</span>
 							{/if}
@@ -143,10 +136,12 @@
 									id={row.accountId}
 									name={row.accountName}
 									isShared={row.accountIsShared}
-									class="text-foreground/80 text-sm"
+									class="cell-truncate text-foreground/80 text-sm"
 								/>
 							{:else if row.accountName}
-								<span class="text-foreground/80 text-sm">{row.accountName}</span>
+								<span class="cell-truncate text-foreground/80 text-sm" title={row.accountName}
+									>{row.accountName}</span
+								>
 							{:else}
 								<span class="text-muted-foreground text-sm">~</span>
 							{/if}

--- a/src/routes/(app)/trades/trades-table.svelte
+++ b/src/routes/(app)/trades/trades-table.svelte
@@ -42,11 +42,11 @@
 </script>
 
 {#if tradesContext.totalItems === 0}
-	<Empty>
+	<Empty class="full-bleed">
 		{m.trades_table_empty()}
 	</Empty>
 {:else}
-	<div class="bg-background overflow-hidden rounded-sm shadow-md">
+	<div class="full-bleed bg-background overflow-hidden rounded-sm shadow-md">
 		<Table.Root>
 			<Table.Header>
 				<Table.Row>

--- a/src/routes/(app)/transactions/+page.svelte
+++ b/src/routes/(app)/transactions/+page.svelte
@@ -56,7 +56,7 @@
 			<TransactionSummary />
 			{#if txContext.selectedCount > 0}
 				<div
-					class="bg-brand-secondary border-border flex h-12 items-center justify-between rounded-sm border pr-2 pl-4"
+					class="bg-brand-secondary border-border flex h-12 items-center justify-between rounded-sm border pr-2 pl-4 max-sm:mb-4"
 					transition:slide={{ duration: 150 }}
 				>
 					<span class="text-sm font-semibold tracking-tight">

--- a/src/routes/(app)/transactions/transaction-summary.svelte
+++ b/src/routes/(app)/transactions/transaction-summary.svelte
@@ -18,7 +18,11 @@
 	);
 </script>
 
-<div role="region" aria-label={m.transactions_summary_aria_label()} class="grid gap-2 {columns}">
+<div
+	role="region"
+	aria-label={m.transactions_summary_aria_label()}
+	class="grid gap-2 max-sm:mb-3.5 {columns}"
+>
 	<KeyValue
 		title={m.transactions_summary_count_label()}
 		value={txContext.totalItems}

--- a/src/routes/(app)/transactions/transaction-table.svelte
+++ b/src/routes/(app)/transactions/transaction-table.svelte
@@ -10,7 +10,6 @@
 	import * as Pagination from '$lib/components/ui/pagination/index';
 	import * as Table from '$lib/components/ui/table/index';
 	import * as Tooltip from '$lib/components/ui/tooltip/index.js';
-	import { getFormattingLocale } from '$lib/interface-preferences.svelte';
 	import { m } from '$lib/paraglide/messages';
 	import { getTransactionsContext } from '$lib/transactions.svelte';
 	import { cn } from '$lib/utils.js';
@@ -25,17 +24,6 @@
 
 	function handleSort(column: string) {
 		txContext.setSort(column);
-	}
-
-	const dateFormatter = new Intl.DateTimeFormat(getFormattingLocale(), {
-		year: 'numeric',
-		month: 'short',
-		day: 'numeric',
-		timeZone: 'UTC'
-	});
-
-	function formatDate(date: Date) {
-		return dateFormatter.format(date);
 	}
 
 	function amountClass(value: number) {
@@ -54,7 +42,7 @@
 		<Table.Root>
 			<Table.Header>
 				<Table.Row>
-					<Table.Head class="w-10 pl-4">
+					<Table.Head class="w-10">
 						<Checkbox
 							checked={txContext.isAllVisibleSelected}
 							indeterminate={txContext.isIndeterminate}
@@ -122,7 +110,7 @@
 								? '[&>td]:bg-brand-secondary odd:[&>td]:bg-brand-secondary'
 								: ''}
 					>
-						<Table.Cell class="w-10 pl-4">
+						<Table.Cell class="w-10">
 							<Checkbox
 								checked={isSelected}
 								onCheckedChange={() => txContext.toggleSelection(row.id)}
@@ -131,14 +119,15 @@
 						<Table.Cell
 							class="text-muted-foreground font-mono whitespace-nowrap uppercase tabular-nums"
 						>
-							{formatDate(row.date)}
+							{row.date.toISOString().slice(0, 10)}
 						</Table.Cell>
 						<Table.Cell>
 							{#if row.description}
 								<Link
 									href="/transactions/{row.id}"
 									onclick={(event) => openTransaction(event, row.id)}
-									class="text-foreground/90 text-sm font-medium"
+									title={row.description}
+									class="cell-truncate text-foreground/90 text-sm font-medium"
 								>
 									{row.description}
 								</Link>
@@ -152,7 +141,7 @@
 						</Table.Cell>
 						<Table.Cell>
 							{#if row.labelChips.length}
-								<div class="flex flex-wrap gap-2">
+								<div class="flex flex-wrap gap-2 max-sm:max-w-[18ch]">
 									{#each row.labelChips as label (label.id)}
 										{@const isActive = txContext.labelFilters.includes(label.id)}
 										<button
@@ -180,10 +169,12 @@
 									id={row.accountId}
 									name={row.accountName}
 									isShared={row.accountIsShared}
-									class="text-foreground/80 text-sm"
+									class="cell-truncate text-foreground/80 text-sm"
 								/>
 							{:else if row.accountName}
-								<span class="text-foreground/80 text-sm">{row.accountName}</span>
+								<span class="cell-truncate text-foreground/80 text-sm" title={row.accountName}
+									>{row.accountName}</span
+								>
 							{:else}
 								<span class="text-muted-foreground text-sm">~</span>
 							{/if}

--- a/src/routes/(app)/transactions/transaction-table.svelte
+++ b/src/routes/(app)/transactions/transaction-table.svelte
@@ -46,11 +46,11 @@
 </script>
 
 {#if txContext.totalItems === 0}
-	<Empty>
+	<Empty class="full-bleed">
 		{m.transactions_table_empty()}
 	</Empty>
 {:else}
-	<div class="bg-background overflow-hidden rounded-sm shadow-md">
+	<div class="full-bleed bg-background overflow-hidden rounded-sm shadow-md">
 		<Table.Root>
 			<Table.Header>
 				<Table.Row>

--- a/src/routes/(app)/trends/performance.svelte
+++ b/src/routes/(app)/trends/performance.svelte
@@ -481,11 +481,11 @@
 {/snippet}
 
 {#if isLoading}
-	<Skeleton class="h-64" showSpinner />
+	<Skeleton class="full-bleed h-64" showSpinner />
 {:else if isEmpty}
-	<Empty>{m.trends_empty()}</Empty>
+	<Empty class="full-bleed">{m.trends_empty()}</Empty>
 {:else}
-	<div class="bg-background rounded-sm shadow-md">
+	<div class="full-bleed bg-background rounded-sm shadow-md">
 		<div class="overflow-x-auto">
 			<Tooltip.Provider delayDuration={150}>
 				<Table.Root>


### PR DESCRIPTION
- Charts and tables now render full-width on small viewports via a shared `.full-bleed` utility, keeping only their internal padding
- The big-picture cashflow chart uses single-letter month labels on phones so columns no longer crowd
- Time-series charts overlay compact y-axis labels ($200K) inside the plot and shorten x-axis dates, reclaiming both gutters for data
- Chart tooltips are touch-aware: scrolling through a chart no longer strands them, tapping pins them, and a horizontal drag scrubs along the data points
- Dashed-underline cell tooltips open on tap and dismiss on tap-away, and tooltips get a darker surface in dark mode for contrast
- Breadcrumbs stay on a single line at any width, truncating the middle crumb instead of wrapping under the status bar

Refs #391