### PR TITLE
fix: reconcile balances when linking Plaid to existing accounts

### DIFF
--- a/e2e/plaid.link.test.ts
+++ b/e2e/plaid.link.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { subDays } from 'date-fns';
 
 import { AccountsBalanceGroupOptions } from '../src/lib/pocketbase.schema';
 import { setPlaidItem, stubPlaidWidget } from './plaid.helpers';
@@ -74,8 +75,9 @@ test('matches an existing account, adopts its transaction, and preserves derived
 }) => {
 	const user = await seedUser('lucien');
 	const publicToken = `public-token-${user.id}`;
-	const openingDate = '2025-01-01';
-	const matchedDate = '2025-02-01';
+	const matchedAt = new Date();
+	const openingDate = formatDateForInput(subDays(matchedAt, 30));
+	const matchedDate = formatDateForInput(matchedAt);
 
 	const existingAccount = await seedAccount({
 		name: 'Household Checking',

--- a/e2e/plaid.link.test.ts
+++ b/e2e/plaid.link.test.ts
@@ -3,7 +3,14 @@ import { expect, test } from '@playwright/test';
 import { AccountsBalanceGroupOptions } from '../src/lib/pocketbase.schema';
 import { setPlaidItem, stubPlaidWidget } from './plaid.helpers';
 import { formatDateForInput, goToPageViaSidebar, signIn } from './playwright.helpers';
-import { seedAccount, seedTransaction, seedUser } from './pocketbase.helpers';
+import {
+	getUserPB,
+	listAccountBalances,
+	seedAccount,
+	seedAccountBalance,
+	seedTransaction,
+	seedUser
+} from './pocketbase.helpers';
 
 test('links a bank through the Plaid widget and syncs its transactions', async ({ page }) => {
 	const user = await seedUser('marcel');
@@ -62,25 +69,34 @@ test('links a bank through the Plaid widget and syncs its transactions', async (
 	await expect(page.getByRole('row', { name: 'Fake Coffee Roasters' })).toBeVisible();
 });
 
-test('matches a bank account to an existing account and adopts its manual transaction', async ({
+test('matches an existing account, adopts its transaction, and preserves derived history', async ({
 	page
 }) => {
 	const user = await seedUser('lucien');
 	const publicToken = `public-token-${user.id}`;
-	const today = formatDateForInput(new Date());
+	const openingDate = '2025-01-01';
+	const matchedDate = '2025-02-01';
 
 	const existingAccount = await seedAccount({
 		name: 'Household Checking',
 		balanceGroup: AccountsBalanceGroupOptions.CASH,
 		balanceType: 'Checking',
-		owner: user.id
+		owner: user.id,
+		autoCalculated: new Date().toISOString()
+	});
+	await seedTransaction({
+		account: existingAccount.id,
+		owner: user.id,
+		date: `${openingDate}T12:00:00.000Z`,
+		description: 'Opening deposit',
+		value: 100
 	});
 	// Same account, day and amount as the Plaid transaction below, so the first sync has an
 	// unambiguous manual counterpart to adopt instead of a second copy to create.
 	await seedTransaction({
 		account: existingAccount.id,
 		owner: user.id,
-		date: `${today}T12:00:00.000Z`,
+		date: `${matchedDate}T12:00:00.000Z`,
 		description: 'Fake Coffee Roasters',
 		value: -4.5
 	});
@@ -111,7 +127,7 @@ test('matches a bank account to an existing account and adopts its manual transa
 					{
 						account_id: 'fake-checking',
 						transaction_id: 'fake-transaction-coffee',
-						date: today,
+						date: matchedDate,
 						name: 'Coffee',
 						original_description: 'Fake Coffee Roasters',
 						amount: 4.5
@@ -119,7 +135,7 @@ test('matches a bank account to an existing account and adopts its manual transa
 					{
 						account_id: 'fake-checking',
 						transaction_id: 'fake-transaction-books',
-						date: today,
+						date: matchedDate,
 						name: 'Books',
 						original_description: 'Fake Bookstore',
 						amount: 18
@@ -165,6 +181,22 @@ test('matches a bank account to an existing account and adopts its manual transa
 	await expect(page.getByRole('row', { name: 'Household Checking' })).toBeVisible();
 	await expect(page.getByRole('row', { name: 'Everyday Checking' })).toHaveCount(0);
 
+	const userPB = await getUserPB(user.email);
+	const linkedAccount = await userPB.collection('accounts').getOne(existingAccount.id);
+	const materializedHistory = (await listAccountBalances(userPB, existingAccount.id))
+		.filter(
+			(balance) =>
+				balance.source === 'derived' &&
+				[openingDate, matchedDate].includes(balance.asOf.slice(0, 10))
+		)
+		.map((balance) => ({ date: balance.asOf.slice(0, 10), value: balance.value }))
+		.sort((left, right) => left.date.localeCompare(right.date));
+	expect(linkedAccount.autoCalculated).toBe('');
+	expect(materializedHistory).toEqual([
+		{ date: openingDate, value: 100 },
+		{ date: matchedDate, value: 95.5 }
+	]);
+
 	// The new transaction landing is what proves the sync ran, so the coffee count below is read
 	// after the reconciliation had its chance to duplicate it.
 	await goToPageViaSidebar(page, 'Transactions');
@@ -173,6 +205,74 @@ test('matches a bank account to an existing account and adopts its manual transa
 
 	await goToPageViaSidebar(page, 'Accounts');
 	await expect(page.getByRole('row', { name: 'Platinum Card' })).toContainText('-$450.00');
+});
+
+test('derives investment cash when linking to an existing account', async ({ page }) => {
+	const user = await seedUser('desmond');
+	const publicToken = `public-token-${user.id}`;
+	const existingAccount = await seedAccount({
+		name: 'Retirement Fund',
+		balanceGroup: AccountsBalanceGroupOptions.INVESTMENT,
+		balanceType: 'Brokerage',
+		owner: user.id
+	});
+	await seedAccountBalance({
+		account: existingAccount.id,
+		owner: user.id,
+		asOf: '2020-01-01T12:00:00.000Z',
+		value: 700
+	});
+	await setPlaidItem({
+		publicToken,
+		accounts: [
+			{
+				account_id: 'fake-investment',
+				name: 'Investment Account',
+				mask: '6789',
+				type: 'investment',
+				subtype: 'brokerage',
+				balances: { current: 1000, iso_currency_code: 'USD' }
+			}
+		],
+		holdings: [
+			{
+				account_id: 'fake-investment',
+				security_id: 'fake-security',
+				quantity: 8,
+				institution_price: 100,
+				institution_value: 800
+			}
+		],
+		securities: [
+			{
+				security_id: 'fake-security',
+				name: 'Fake Index Fund',
+				ticker_symbol: 'FAKE',
+				type: 'equity',
+				iso_currency_code: 'USD'
+			}
+		]
+	});
+	await stubPlaidWidget(page, {
+		publicToken,
+		institutionName: 'Fake Brokerage',
+		outcome: 'success'
+	});
+
+	await page.goto('/');
+	await signIn(page, user.email);
+	await goToPageViaSidebar(page, 'Accounts');
+	await expect(page.getByRole('row', { name: 'Retirement Fund' })).toContainText('$700.00');
+
+	await page.getByRole('link', { name: 'Add account' }).click();
+	await page.getByRole('link', { name: 'Link account' }).click();
+	await expect(page.getByText('Match accounts')).toBeVisible();
+
+	await page.getByLabel('Link to').click();
+	await page.getByRole('option', { name: 'Retirement Fund' }).click();
+	await page.getByRole('button', { name: 'Confirm' }).click();
+	await expect(page.getByText('Accounts linked', { exact: true })).toBeVisible();
+	await expect(page.getByRole('row', { name: 'Retirement Fund' })).toContainText('$1,000.00');
 });
 
 test('discarding the match step deletes the bank connection', async ({ page }) => {

--- a/pocketbase/balance.go
+++ b/pocketbase/balance.go
@@ -212,3 +212,82 @@ func recomputeDerivedBalance(app core.App, accountID string, importSession strin
 	}
 	return nil
 }
+
+func materializeAccountBalanceHistoryOnLink(e *core.RecordEvent) error {
+	original := e.Record.Original()
+	// Connected accounts are saved with auto-calculation cleared; the original record identifies
+	// the one-time link transition whose live transaction history must become durable snapshots.
+	if original.GetDateTime("autoCalculated").IsZero() ||
+		original.GetString("connection") != "" ||
+		e.Record.GetString("connection") == "" ||
+		!e.Record.GetDateTime("autoCalculated").IsZero() {
+		return e.Next()
+	}
+
+	owner := e.Record.GetString("owner")
+	transactions, err := e.App.FindRecordsByFilter(
+		"transactions", "account = {:account} && owner = {:owner}", "date,created,id", 0, 0,
+		map[string]any{"account": e.Record.Id, "owner": owner},
+	)
+	if err != nil {
+		return fmt.Errorf("find transactions for linked account history: %w", err)
+	}
+
+	type balancePoint struct {
+		asOf  time.Time
+		value float64
+	}
+	var points []balancePoint
+	var running float64
+	for _, transaction := range transactions {
+		if !transaction.GetDateTime("excluded").IsZero() {
+			continue
+		}
+		running += transaction.GetFloat("value")
+		asOf := transaction.GetDateTime("date").Time()
+		if len(points) > 0 && points[len(points)-1].asOf.Equal(asOf) {
+			points[len(points)-1].value = running
+			continue
+		}
+		points = append(points, balancePoint{asOf: asOf, value: running})
+	}
+	if len(points) == 0 {
+		return e.Next()
+	}
+
+	collection, err := e.App.FindCollectionByNameOrId("accountBalances")
+	if err != nil {
+		return fmt.Errorf("find accountBalances collection for linked account history: %w", err)
+	}
+	for _, point := range points {
+		start, end := pbDateRange(point.asOf.Format("2006-01-02"))
+		_, err := e.App.FindFirstRecordByFilter("accountBalances",
+			"account = {:account} && asOf >= {:start} && asOf < {:end} && value = {:value} && owner = {:owner}",
+			map[string]any{
+				"account": e.Record.Id,
+				"start":   start,
+				"end":     end,
+				"value":   point.value,
+				"owner":   owner,
+			},
+		)
+		if err == nil {
+			continue
+		}
+		if !errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("find linked account history duplicate: %w", err)
+		}
+
+		balance := core.NewRecord(collection)
+		balance.Set("account", e.Record.Id)
+		balance.Set("asOf", point.asOf)
+		balance.Set("value", point.value)
+		balance.Set("owner", owner)
+		balance.Set("source", "derived")
+		if err := e.App.Save(balance); err != nil {
+			return fmt.Errorf("save linked account history snapshot: %w", err)
+		}
+	}
+
+	return e.Next()
+}

--- a/pocketbase/main.go
+++ b/pocketbase/main.go
@@ -374,6 +374,8 @@ func main() {
 		return e.Next()
 	})
 
+	app.OnRecordAfterUpdateSuccess("accounts").BindFunc(materializeAccountBalanceHistoryOnLink)
+
 	app.OnRecordAfterUpdateSuccess("accounts", "assets", "securities").BindFunc(func(e *core.RecordEvent) error {
 		enqueueRatesForContainer(e.App, e.Record)
 		return e.Next()

--- a/pocketbase/plaid_sync.go
+++ b/pocketbase/plaid_sync.go
@@ -410,6 +410,40 @@ func syncConnection(app core.App, connection *core.Record) (plaidSyncSummary, er
 		return failedSummary, errors.Join(err, finishErr)
 	}
 	asOf := time.Now().UTC()
+	writeCashSnapshot := func(account *core.Record, value float64) {
+		start, end := pbDateRange(asOf.Format("2006-01-02"))
+		_, err := app.FindFirstRecordByFilter("accountBalances",
+			"account = {:account} && asOf >= {:start} && asOf < {:end} && value = {:value} && owner = {:owner}",
+			map[string]any{
+				"account": account.Id,
+				"start":   start,
+				"end":     end,
+				"value":   value,
+				"owner":   ownerID,
+			},
+		)
+		if err == nil {
+			summary.Skipped++
+			return
+		}
+		if !errors.Is(err, sql.ErrNoRows) {
+			recordFailure("accountBalances", "find duplicate", err)
+			return
+		}
+
+		balance := core.NewRecord(balanceCollection)
+		balance.Set("account", account.Id)
+		balance.Set("value", value)
+		balance.Set("asOf", asOf)
+		balance.Set("owner", ownerID)
+		balance.Set("importSession", session.Id)
+		balance.Set("source", "import")
+		if err := app.Save(balance); err != nil {
+			recordFailure("accountBalances", "save snapshot", err)
+			return
+		}
+		summary.Created++
+	}
 	registeredCurrencies := map[string]bool{}
 	var investmentAccounts []plaidProviderAccount
 	for _, providerAccount := range accountsResponse.Accounts {
@@ -454,38 +488,7 @@ func syncConnection(app core.App, connection *core.Record) (plaidSyncSummary, er
 			continue
 		}
 
-		start, end := pbDateRange(asOf.Format("2006-01-02"))
-		_, err := app.FindFirstRecordByFilter("accountBalances",
-			"account = {:account} && asOf >= {:start} && asOf < {:end} && value = {:value} && owner = {:owner}",
-			map[string]any{
-				"account": account.Id,
-				"start":   start,
-				"end":     end,
-				"value":   *currentBalance,
-				"owner":   ownerID,
-			},
-		)
-		if err == nil {
-			summary.Skipped++
-			continue
-		}
-		if !errors.Is(err, sql.ErrNoRows) {
-			recordFailure("accountBalances", "find duplicate", err)
-			continue
-		}
-
-		balance := core.NewRecord(balanceCollection)
-		balance.Set("account", account.Id)
-		balance.Set("value", *currentBalance)
-		balance.Set("asOf", asOf)
-		balance.Set("owner", ownerID)
-		balance.Set("importSession", session.Id)
-		balance.Set("source", "import")
-		if err := app.Save(balance); err != nil {
-			recordFailure("accountBalances", "save snapshot", err)
-			continue
-		}
-		summary.Created++
+		writeCashSnapshot(account, *currentBalance)
 	}
 
 	investmentFailuresBefore := summary.Failed
@@ -607,55 +610,21 @@ func syncConnection(app core.App, connection *core.Record) (plaidSyncSummary, er
 			for _, providerAccount := range investmentAccounts {
 				account := accountsByPlaidID[providerAccount.AccountID]
 				currentBalance := plaidBalanceForCanutin(providerAccount.Type, providerAccount.Balances.Current)
-				if currentBalance == nil {
-					recordFailure("accountBalances", "derive cash snapshot", errors.New("current balance is unavailable"))
-					cashSnapshotDataFailures++
-					investmentCashFailures++
-				}
-				if unknownHoldingValues[providerAccount.AccountID] {
-					recordFailure("accountBalances", "derive cash snapshot", errors.New("holding value is unavailable"))
-					cashSnapshotDataFailures++
-					investmentCashFailures++
-				}
 				if currentBalance == nil || unknownHoldingValues[providerAccount.AccountID] {
+					reason := errors.New("current balance is unavailable")
+					if currentBalance != nil {
+						reason = errors.New("holding value is unavailable")
+					}
+					recordFailure("accountBalances", "derive cash snapshot", reason)
+					cashSnapshotDataFailures++
+					investmentCashFailures++
 					continue
 				}
 
 				// Plaid's investment current balance is the total account value. Some institutions
 				// include cash as a holding and others do not, so the remainder is the cash snapshot.
 				cashBalance := *currentBalance - holdingValues[providerAccount.AccountID]
-				start, end := pbDateRange(asOf.Format("2006-01-02"))
-				_, err := app.FindFirstRecordByFilter("accountBalances",
-					"account = {:account} && asOf >= {:start} && asOf < {:end} && value = {:value} && owner = {:owner}",
-					map[string]any{
-						"account": account.Id,
-						"start":   start,
-						"end":     end,
-						"value":   cashBalance,
-						"owner":   ownerID,
-					},
-				)
-				if err == nil {
-					summary.Skipped++
-					continue
-				}
-				if !errors.Is(err, sql.ErrNoRows) {
-					recordFailure("accountBalances", "find duplicate", err)
-					continue
-				}
-
-				balance := core.NewRecord(balanceCollection)
-				balance.Set("account", account.Id)
-				balance.Set("value", cashBalance)
-				balance.Set("asOf", asOf)
-				balance.Set("owner", ownerID)
-				balance.Set("importSession", session.Id)
-				balance.Set("source", "import")
-				if err := app.Save(balance); err != nil {
-					recordFailure("accountBalances", "save snapshot", err)
-					continue
-				}
-				summary.Created++
+				writeCashSnapshot(account, cashBalance)
 			}
 		}
 

--- a/pocketbase/plaid_sync.go
+++ b/pocketbase/plaid_sync.go
@@ -315,6 +315,7 @@ func syncConnection(app core.App, connection *core.Record) (plaidSyncSummary, er
 		summary.Failed++
 		logEvent("plaidSync", fmt.Sprintf("connection=%s session=%s collection=%s op=%s", connection.Id, session.Id, collection, operation), err)
 	}
+	cashSnapshotDataFailures := 0
 
 	for _, batch := range []struct {
 		transactions []plaidCashTransaction
@@ -410,14 +411,14 @@ func syncConnection(app core.App, connection *core.Record) (plaidSyncSummary, er
 	}
 	asOf := time.Now().UTC()
 	registeredCurrencies := map[string]bool{}
-	var investmentAccountIDs []string
+	var investmentAccounts []plaidProviderAccount
 	for _, providerAccount := range accountsResponse.Accounts {
 		account := accountsByPlaidID[providerAccount.AccountID]
 		if account == nil {
 			continue
 		}
 		if providerAccount.Type == "investment" {
-			investmentAccountIDs = append(investmentAccountIDs, providerAccount.AccountID)
+			investmentAccounts = append(investmentAccounts, providerAccount)
 			continue
 		}
 
@@ -447,8 +448,9 @@ func syncConnection(app core.App, connection *core.Record) (plaidSyncSummary, er
 		}
 		currentBalance := plaidBalanceForCanutin(providerAccount.Type, providerAccount.Balances.Current)
 		// A reported zero is a real balance; nil means Plaid did not provide a current balance.
-		if !account.GetDateTime("autoCalculated").IsZero() || currentBalance == nil {
-			summary.Skipped++
+		if currentBalance == nil {
+			recordFailure("accountBalances", "derive cash snapshot", errors.New("current balance is unavailable"))
+			cashSnapshotDataFailures++
 			continue
 		}
 
@@ -487,11 +489,17 @@ func syncConnection(app core.App, connection *core.Record) (plaidSyncSummary, er
 	}
 
 	investmentFailuresBefore := summary.Failed
+	investmentCashFailures := 0
 	investmentsAvailable := true
-	if len(investmentAccountIDs) > 0 {
+	if len(investmentAccounts) > 0 {
+		investmentAccountIDs := make([]string, len(investmentAccounts))
+		for index, providerAccount := range investmentAccounts {
+			investmentAccountIDs[index] = providerAccount.AccountID
+		}
 		providerSecurities := map[string]plaidInvestmentSecurity{}
 		var holdings []plaidHolding
 		var investmentTransactions []plaidInvestmentTransaction
+		holdingsFetched := false
 
 		holdingsRequest := struct {
 			ClientID    string `json:"client_id"`
@@ -519,6 +527,7 @@ func syncConnection(app core.App, connection *core.Record) (plaidSyncSummary, er
 				recordFailure("securityBalances", "fetch holdings", err)
 			}
 		} else {
+			holdingsFetched = true
 			holdings = holdingsResponse.Holdings
 			for _, security := range holdingsResponse.Securities {
 				providerSecurities[security.SecurityID] = security
@@ -581,6 +590,72 @@ func syncConnection(app core.App, connection *core.Record) (plaidSyncSummary, er
 					recordFailure("securityTransactions", "paginate transactions", errors.New("Plaid returned more investment transactions without advancing the offset"))
 					break
 				}
+			}
+		}
+
+		if investmentsAvailable && holdingsFetched {
+			holdingValues := map[string]float64{}
+			unknownHoldingValues := map[string]bool{}
+			for _, holding := range holdings {
+				if holding.InstitutionValue == nil {
+					unknownHoldingValues[holding.AccountID] = true
+					continue
+				}
+				holdingValues[holding.AccountID] += *holding.InstitutionValue
+			}
+
+			for _, providerAccount := range investmentAccounts {
+				account := accountsByPlaidID[providerAccount.AccountID]
+				currentBalance := plaidBalanceForCanutin(providerAccount.Type, providerAccount.Balances.Current)
+				if currentBalance == nil {
+					recordFailure("accountBalances", "derive cash snapshot", errors.New("current balance is unavailable"))
+					cashSnapshotDataFailures++
+					investmentCashFailures++
+				}
+				if unknownHoldingValues[providerAccount.AccountID] {
+					recordFailure("accountBalances", "derive cash snapshot", errors.New("holding value is unavailable"))
+					cashSnapshotDataFailures++
+					investmentCashFailures++
+				}
+				if currentBalance == nil || unknownHoldingValues[providerAccount.AccountID] {
+					continue
+				}
+
+				// Plaid's investment current balance is the total account value. Some institutions
+				// include cash as a holding and others do not, so the remainder is the cash snapshot.
+				cashBalance := *currentBalance - holdingValues[providerAccount.AccountID]
+				start, end := pbDateRange(asOf.Format("2006-01-02"))
+				_, err := app.FindFirstRecordByFilter("accountBalances",
+					"account = {:account} && asOf >= {:start} && asOf < {:end} && value = {:value} && owner = {:owner}",
+					map[string]any{
+						"account": account.Id,
+						"start":   start,
+						"end":     end,
+						"value":   cashBalance,
+						"owner":   ownerID,
+					},
+				)
+				if err == nil {
+					summary.Skipped++
+					continue
+				}
+				if !errors.Is(err, sql.ErrNoRows) {
+					recordFailure("accountBalances", "find duplicate", err)
+					continue
+				}
+
+				balance := core.NewRecord(balanceCollection)
+				balance.Set("account", account.Id)
+				balance.Set("value", cashBalance)
+				balance.Set("asOf", asOf)
+				balance.Set("owner", ownerID)
+				balance.Set("importSession", session.Id)
+				balance.Set("source", "import")
+				if err := app.Save(balance); err != nil {
+					recordFailure("accountBalances", "save snapshot", err)
+					continue
+				}
+				summary.Created++
 			}
 		}
 
@@ -804,13 +879,13 @@ func syncConnection(app core.App, connection *core.Record) (plaidSyncSummary, er
 			}
 		}
 	}
-	// Only a complete investment fetch and apply advances the window. No accounts is complete;
-	// unavailable products retry the prior window.
-	investmentsPhaseSucceeded = investmentsAvailable && summary.Failed == investmentFailuresBefore
+	// Cash data quality does not indicate missed investment transactions, so those failures do not
+	// hold back the transaction window. Unavailable or incomplete investment fetches still do.
+	investmentsPhaseSucceeded = investmentsAvailable && summary.Failed == investmentFailuresBefore+investmentCashFailures
 
 	if summary.Failed > 0 {
 		status := importStatusFailed
-		if summary.Created > 0 || summary.Failed > investmentFailuresBefore {
+		if summary.Created > 0 || cashSnapshotDataFailures > 0 || summary.Failed > investmentFailuresBefore {
 			status = importStatusCompletedWithErrors
 		}
 		return finish(status, "error", cursorAfterApplication)

--- a/pocketbase/skill.go
+++ b/pocketbase/skill.go
@@ -128,13 +128,16 @@ const skillCustomEndpointsSection = "## Custom endpoints\n\n" +
 	"transaction reuses exactly one existing transaction with the same account, owner, calendar date, value, and normalized " +
 	"description, attaching the Plaid transaction ID while preserving its labels, exclusion state, notes, and original import session; " +
 	"ambiguous matches remain separate. " +
-	"It applies adds, modifications, and removals to matched accounts, and imports current balance snapshots only for " +
-	"non-investment accounts that are not auto-calculated. For matched investment accounts it imports current holdings " +
+	"It applies adds, modifications, and removals to matched accounts, and imports current balance snapshots for " +
+	"non-investment accounts. For matched investment accounts with complete balance and holding values, " +
+	"it stores cash as Plaid's current total minus the summed holding values, and imports current holdings " +
 	"snapshots and investment transactions from 30 days before the previous sync (or from 1990-01-01 on the " +
-	"first sync). The cursor advances after every page and all added, modified, and removed cash transactions " +
+	"first sync). Missing current balances or holding values preserve the previous cash snapshot and are reported as failures. " +
+	"The cursor advances after every page and all added, modified, and removed cash transactions " +
 	"apply successfully; balance, currency, holding, and investment-transaction failures are reported without " +
-	"holding it back. The investment sync time advances only after investments are fetched and applied without " +
-	"failures, or when there are no investment accounts; unavailable investment data preserves the previous window. " +
+	"holding it back. The investment sync time advances only after investments are fetched and holdings and transactions " +
+	"apply without failures, or when there are no investment accounts; cash data-quality failures do not hold it back, " +
+	"while unavailable investment data preserves the previous window. " +
 	"Returns `{ sessionId, created, skipped, failed, status }`; concurrent syncs of the " +
 	"same connection return `{ error: \"plaid_sync_in_progress\" }` with status 409, " +
 	"and a connection requiring renewed Plaid login completes with status `failed` and is marked " +
@@ -172,7 +175,10 @@ Backend hooks enforce invariants that are not visible in the access rules:
   in one column: cash comes from the latest ` + "`accountBalances`" + ` snapshot, positions from
   ` + "`securityBalances`" + ` holding snapshots. Holdings come exclusively from ` + "`securityBalances`" + `;
   ` + "`securityTransactions`" + ` are display-only trade history that never affect balances. Writing
-  portfolio value into an account balance double-counts it.
+  portfolio value into an account balance double-counts it. Plaid reports an investment account's
+  current balance as its total value, so sync stores cash as that total minus the sum of the account's
+  reported holding values. If the current balance or any holding value is unknown, sync reports an
+  account-balance failure and preserves the previous cash snapshot.
 - Number fields on ` + "`securityBalances`" + ` and ` + "`securityTransactions`" + ` are nullable:
   ` + "`null`" + ` (or an omitted field) means unknown, while ` + "`0`" + ` is a known zero. When resolving
   ` + "`securityBalances`" + ` snapshots, market value (` + "`value`" + `) carries forward from the most recent
@@ -185,8 +191,9 @@ Backend hooks enforce invariants that are not visible in the access rules:
 - Setting ` + "`autoCalculated`" + ` on an account makes the engine recompute its latest cash balance by
   summing imported cash transactions into a new ` + "`source = derived`" + ` row stamped with the current
   time, which overrides any imported cash snapshot and re-fires on later transaction edits. Leave it
-  off to preserve an imported snapshot. Accounts linked to Plaid always force it off so Plaid's balance
-  snapshots remain authoritative.
+  off to preserve an imported snapshot. When an auto-calculated account is first linked to Plaid, the
+  engine materializes its running non-excluded transaction balance at each transaction date while
+  forcing auto-calculation off, preserving the account's cash history while Plaid snapshots become authoritative.
 - Share records (` + "`accountShares`" + `, ` + "`assetShares`" + `) can only be updated by the recipient,
   and only the ` + "`includeInNetWorth`" + ` field may change. The sharer must revoke and recreate
   a share to change anything else.


### PR DESCRIPTION
- Linking a Plaid item to an existing investment account double-counted its value: the old manual cash balance stayed "latest" while synced holdings were added on top of it.
- Sync now derives investment cash as Plaid's reported total minus the summed holding values, so cash plus positions always equals what the institution reports — including institutions that report cash as a holding.
- A missing current balance or an unpriced holding is now reported as a sync failure instead of a silent skip, surfacing in the sync toast and the imports table; these data-quality failures do not hold back the investment transaction window.
- Linking an auto-calculated account now materializes its transaction-derived balance history into durable balance rows before auto-calculation is forced off, so the account's chart keeps its pre-link curve.
- Removed the unreachable auto-calculated guards in the sync cash loops; connected accounts always have the flag cleared.
- Extended e2e coverage: derived investment cash when linking to an existing account, and preserved history plus cleared flag in the adopted-account scenario.

No linked issue