### PR TITLE
fix: stamp Plaid cash snapshots at midnight and keep link button label

### DIFF
--- a/e2e/plaid.link.test.ts
+++ b/e2e/plaid.link.test.ts
@@ -275,6 +275,13 @@ test('derives investment cash when linking to an existing account', async ({ pag
 	await page.getByRole('button', { name: 'Confirm' }).click();
 	await expect(page.getByText('Accounts linked', { exact: true })).toBeVisible();
 	await expect(page.getByRole('row', { name: 'Retirement Fund' })).toContainText('$1,000.00');
+
+	const userPB = await getUserPB(user.email);
+	const importedCashBalance = (await listAccountBalances(userPB, existingAccount.id)).find(
+		(balance) => balance.source === 'import'
+	);
+	expect(importedCashBalance?.value).toBe(200);
+	expect(importedCashBalance?.asOf).toBe(`${formatDateForInput(new Date())} 00:00:00.000Z`);
 });
 
 test('discarding the match step deletes the bank connection', async ({ page }) => {

--- a/messages/en.json
+++ b/messages/en.json
@@ -112,7 +112,7 @@
 	"accounts_link_empty": "Plaid didn't return any accounts",
 	"accounts_link_cancel": "Cancel",
 	"accounts_link_confirm": "Confirm",
-	"accounts_link_confirming": "Linking accounts",
+	"accounts_link_loading": "Linking accounts",
 	"accounts_link_discard_confirm_title": "Discard this bank connection?",
 	"accounts_link_discard_confirm_description": "The bank connection will be discarded and no accounts will be created. You can link this bank again later.",
 	"accounts_link_discard_confirm_cancel": "Keep linking",

--- a/messages/es.json
+++ b/messages/es.json
@@ -107,7 +107,7 @@
 	"accounts_link_empty": "Plaid no devolvió ninguna cuenta",
 	"accounts_link_cancel": "Cancelar",
 	"accounts_link_confirm": "Confirmar",
-	"accounts_link_confirming": "Vinculando cuentas",
+	"accounts_link_loading": "Vinculando cuentas",
 	"accounts_link_discard_confirm_title": "¿Descartar esta conexión bancaria?",
 	"accounts_link_discard_confirm_description": "La conexión bancaria se descartará y no se creará ninguna cuenta. Puedes vincular este banco de nuevo más tarde.",
 	"accounts_link_discard_confirm_cancel": "Seguir vinculando",

--- a/pocketbase/plaid_sync.go
+++ b/pocketbase/plaid_sync.go
@@ -410,6 +410,7 @@ func syncConnection(app core.App, connection *core.Record) (plaidSyncSummary, er
 		return failedSummary, errors.Join(err, finishErr)
 	}
 	asOf := time.Now().UTC()
+	cashAsOf := asOf.Truncate(24 * time.Hour)
 	writeCashSnapshot := func(account *core.Record, value float64) {
 		start, end := pbDateRange(asOf.Format("2006-01-02"))
 		_, err := app.FindFirstRecordByFilter("accountBalances",
@@ -434,7 +435,7 @@ func syncConnection(app core.App, connection *core.Record) (plaidSyncSummary, er
 		balance := core.NewRecord(balanceCollection)
 		balance.Set("account", account.Id)
 		balance.Set("value", value)
-		balance.Set("asOf", asOf)
+		balance.Set("asOf", cashAsOf)
 		balance.Set("owner", ownerID)
 		balance.Set("importSession", session.Id)
 		balance.Set("source", "import")

--- a/pocketbase/skill.go
+++ b/pocketbase/skill.go
@@ -131,7 +131,8 @@ const skillCustomEndpointsSection = "## Custom endpoints\n\n" +
 	"It applies adds, modifications, and removals to matched accounts, and imports current balance snapshots for " +
 	"non-investment accounts. For matched investment accounts with complete balance and holding values, " +
 	"it stores cash as Plaid's current total minus the summed holding values, and imports current holdings " +
-	"snapshots and investment transactions from 30 days before the previous sync (or from 1990-01-01 on the " +
+	"snapshots. Cash and holding snapshots are stamped at midnight UTC on the sync date so they supersede together. It imports " +
+	"investment transactions from 30 days before the previous sync (or from 1990-01-01 on the " +
 	"first sync). Missing current balances or holding values preserve the previous cash snapshot and are reported as failures. " +
 	"The cursor advances after every page and all added, modified, and removed cash transactions " +
 	"apply successfully; balance, currency, holding, and investment-transaction failures are reported without " +

--- a/src/routes/(app)/accounts/link/match/+page.svelte
+++ b/src/routes/(app)/accounts/link/match/+page.svelte
@@ -130,6 +130,7 @@
 		}
 
 		isSaving = true;
+		const loadingToast = toast.loading(m.accounts_link_loading());
 		try {
 			for (const account of plaidAccounts) {
 				if (completedPlaidAccountIds.has(account.plaidAccountId)) continue;
@@ -170,10 +171,12 @@
 					logError('plaidLink', 'sync', error);
 					toast.error(m.accounts_link_sync_failed());
 				});
+			toast.dismiss(loadingToast);
 			toast.success(m.accounts_link_success());
 			await goto(resolve('/accounts'));
 		} catch (error) {
 			logError('plaidLink', 'save_matches', error);
+			toast.dismiss(loadingToast);
 			toast.error(m.accounts_link_save_failed());
 			isSaving = false;
 		}
@@ -317,9 +320,7 @@
 								>
 									{m.accounts_link_cancel()}
 								</Button>
-								<Button type="submit" disabled={isSaving}>
-									{isSaving ? m.accounts_link_confirming() : m.accounts_link_confirm()}
-								</Button>
+								<Button type="submit" disabled={isSaving}>{m.accounts_link_confirm()}</Button>
 							</div>
 						</footer>
 					</form>


### PR DESCRIPTION
- Linking a Plaid investment account still produced a one-day balance spike: holdings snapshots are stamped at midnight UTC, but the superseding derived cash snapshot was stamped at sync wall-clock time, leaving a window where new positions were added on top of the old manual cash balance.
- Plaid-written cash snapshots are now stamped at midnight UTC of the sync date, matching the holdings convention, so cash and positions supersede together with no doubled window.
- The e2e investment-link test now asserts both the derived cash value and its midnight timestamp, pinning the regression.
- The match screen's Confirm button no longer swaps its label to "Linking accounts" while saving — it keeps its label and disables, with progress shown by a loading toast that is replaced by the success or error toast.
- The `accounts_link_confirming` message was renamed to `accounts_link_loading` in both locales to reflect its new toast role.

No linked issue