### PR TITLE
fix: rework v1 vault migration, add user docs, restore license

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ FROM node:22-slim
 
 LABEL org.opencontainers.image.source=https://github.com/fmaclen/canutin
 LABEL org.opencontainers.image.description="Personal finance app"
-LABEL org.opencontainers.image.licenses=AGPL-3.0
+LABEL org.opencontainers.image.licenses=Apache-2.0
 
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends ca-certificates \

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2021 Canutin
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,19 @@
-# Canutin v2 (Next)
+# Canutin
 
-This is the next prerelease branch for Canutin v2.
+Canutin is a personal finance app you run on your own server. It keeps your accounts, assets, transactions, and investments in one place and shows you the whole picture: net worth, balance sheet, cash flow trends, and portfolio performance, in any mix of currencies.
+
+Try it at [demo.canutin.com](https://demo.canutin.com).
+
+- Track bank accounts, credit cards, loans, property, vehicles, or anything else with a balance.
+- Browse, label, and filter every transaction.
+- Follow your investments with securities, trades, and portfolio views.
+- Hold balances in multiple currencies with automatic exchange rates.
+- Sync balances and transactions from your bank through [Plaid](docs/plaid.md), using your own Plaid credentials.
+- Let [AI agents](docs/ai-agents.md) import statements, label spending, and answer questions about your data.
+- Import data in bulk through the API, and revert any import that went wrong.
+- Install it as an app on desktop and mobile.
+
+Your data lives in a single SQLite database on your server and is accessible through a fully documented REST API.
 
 ## Self-hosting (Docker)
 
@@ -9,7 +22,7 @@ Create a `docker-compose.yml` file:
 ```yaml
 services:
   pocketbase:
-    image: ghcr.io/fmaclen/canutin:next
+    image: ghcr.io/fmaclen/canutin:latest
     working_dir: /app/pocketbase
     command: ['./pocketbase-custom', 'serve', '--http', '0.0.0.0:42070']
     ports:
@@ -23,12 +36,13 @@ services:
     restart: unless-stopped
 
   sveltekit:
-    image: ghcr.io/fmaclen/canutin:next
+    image: ghcr.io/fmaclen/canutin:latest
     command: ['node', 'build/index.js']
     ports:
       - '42069:42069'
     environment:
-      PUBLIC_PB_URL: 'http://localhost:42070'
+      PUBLIC_PB_URL: ${PUBLIC_PB_URL:-http://localhost:42070}
+      ORIGIN: ${ORIGIN:-http://localhost:42069}
     depends_on:
       - pocketbase
     restart: unless-stopped
@@ -36,16 +50,6 @@ services:
 volumes:
   canutin-data:
 ```
-
-To enable Plaid, create a `.env` file beside `docker-compose.yml` with all three production values:
-
-```dotenv
-PLAID_CLIENT_ID=<client-id>
-PLAID_SECRET=<secret>
-PLAID_ENV=production
-```
-
-`PLAID_ENV` has no default. Use `production` for live data and `sandbox` only for development.
 
 Then run:
 
@@ -63,33 +67,52 @@ On first run, PocketBase needs a superuser to be configured. Get the setup link 
 docker compose logs pocketbase | grep "pbinstal"
 ```
 
-Open the URL in your browser to create your superuser account. Once complete, refresh Canutin to start using the app.
+Open the URL in your browser to create your superuser account. Once complete, refresh Canutin and sign up for your regular user account.
+
+### Serving behind a domain
+
+The defaults above only work on `localhost`. To serve Canutin at a real domain, put both services behind your reverse proxy and set two variables in a `.env` file next to `docker-compose.yml`:
+
+```dotenv
+ORIGIN=https://canutin.example.com
+PUBLIC_PB_URL=https://canutin-pb.example.com
+```
+
+`ORIGIN` is the URL your users load the app from; without it, form submissions fail cross-origin checks. `PUBLIC_PB_URL` is the URL of the PocketBase service and must be reachable from your users' browsers, not just from inside Docker.
+
+### Bank syncing
+
+To sync balances and transactions from your bank, add your Plaid credentials to the same `.env` file. See the [Plaid guide](docs/plaid.md).
+
+## Documentation
+
+- [Migrating from Canutin v1](docs/migrating-from-v1.md)
+- [Syncing banks with Plaid](docs/plaid.md)
+- [Using AI agents with Canutin](docs/ai-agents.md)
 
 ## Development
 
-All you need to start is [Bun](https://bun.sh) installed, then run:
+Canutin is built with SvelteKit, PocketBase, and Bun. All you need to start is [Bun](https://bun.sh) installed, then run:
 
 ```bash
 bun install && bunx playwright install && bun run test
 ```
 
-## Commands
+| Command             | Description                                                                     |
+| ------------------- | ------------------------------------------------------------------------------- |
+| `bun run dev`       | Start Vite dev server                                                           |
+| `bun run build`     | Production build via Vite/SvelteKit                                             |
+| `bun run preview`   | Preview the built app                                                           |
+| `bun run check`     | Type-check with svelte-check                                                    |
+| `bun run lint`      | Prettier check + ESLint                                                         |
+| `bun run verify`    | Non-mutating gate: lint, type-check, and build                                  |
+| `bun run format`    | Auto-format with Prettier (writes files)                                        |
+| `bun run quality`   | Format, lint, and type-check (writes files via format)                          |
+| `bun run test`      | Run Playwright e2e tests                                                        |
+| `bun run pb`        | Ensure and start PocketBase locally (dev)                                       |
+| `bun run pb:import` | Import a Canutin v1 vault, see the [migration guide](docs/migrating-from-v1.md) |
+| `bun run pb:reset`  | Reset (delete) the PocketBase dev database                                      |
 
-| Command                                                                                                                                                                                | Description                                                 |
-| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
-| `bun run dev`                                                                                                                                                                          | Start Vite dev server                                       |
-| `bun run build`                                                                                                                                                                        | Production build via Vite/SvelteKit                         |
-| `bun run preview`                                                                                                                                                                      | Preview the built app                                       |
-| `bun run check`                                                                                                                                                                        | Type-check with svelte-check                                |
-| `bun run check:watch`                                                                                                                                                                  | Type-check in watch mode                                    |
-| `bun run lint`                                                                                                                                                                         | Prettier check + ESLint                                     |
-| `bun run verify`                                                                                                                                                                       | Non-mutating gate: lint, type-check, and build              |
-| `bun run format`                                                                                                                                                                       | Auto-format with Prettier (writes files)                    |
-| `bun run quality`                                                                                                                                                                      | Format, lint, and type-check (writes files via format)      |
-| `bun run test`                                                                                                                                                                         | Run Playwright e2e tests                                    |
-| `bun run pb`                                                                                                                                                                           | Ensure and start PocketBase locally (dev)                   |
-| `bun run pb:import temp/Canutin.demo.vault --email user@example.com --password secret --pb-url http://127.0.0.1:42070 --superuser-email admin@example.com --superuser-password secret` | Import Canutin v1 vault into PocketBase for a specific user |
-| `bun run pb:reset`                                                                                                                                                                     | Reset (delete) the PocketBase dev database                  |
+## License
 
-If the target user already exists, `--password` is optional and the import will reuse that user.
-The import command requires explicit `--pb-url`, `--superuser-email`, and `--superuser-password` options.
+Canutin is open source under the [Apache 2.0 license](LICENSE).

--- a/docs/ai-agents.md
+++ b/docs/ai-agents.md
@@ -1,0 +1,34 @@
+# Using AI agents with Canutin
+
+Every Canutin server publishes a live instruction manual for AI agents. Point an agent at it and the agent learns how to read and write your financial data through Canutin's API: importing transactions from a bank statement, labeling spending, answering questions about your net worth, or filling in balance history.
+
+This works with any agent that can fetch a URL and make HTTP requests, such as Claude, ChatGPT, or a coding agent running on your machine.
+
+## Find your instructions URL
+
+Go to **Settings → Imports**. The **AI agents** section shows your server's **Instructions URL**, which looks like:
+
+```
+https://<your-pocketbase-host>/api/canutin/skill
+```
+
+The page behind that URL is generated on the fly from your server's actual database schema, so it always matches the version of Canutin you are running. You can open it in a browser to see exactly what an agent gets.
+
+## Give it to an agent
+
+Tell the agent the URL and how to sign in. For example:
+
+> Read https://pb.example.com/api/canutin/skill and follow it. Log into my Canutin as user@example.com with password ..., then import the transactions from this CSV into my checking account.
+
+The instructions tell the agent to authenticate with your regular Canutin email and password, and every API request it makes is scoped to your user. It can only see and change your own data, the same as you can when signed in.
+
+Some things agents are good at with this:
+
+- Importing a bank statement (CSV, PDF, or even a screenshot) as transactions, with automatic labeling.
+- Backfilling years of balance history for an account or asset.
+- Answering questions like "what did I spend on restaurants last quarter?"
+- Reverting an import that went wrong, since every bulk import is tracked and undoable.
+
+## A note on credentials
+
+The agent acts with your full user account, so treat it like handing your Canutin password to a very fast assistant. Prefer agents that run on your own machine or that you otherwise trust with credentials, and change your password if you ever want to cut off access.

--- a/docs/migrating-from-v1.md
+++ b/docs/migrating-from-v1.md
@@ -1,0 +1,51 @@
+# Migrating from Canutin v1
+
+Canutin v1 stored everything in a `.vault` file, which is a SQLite database. A script in this repo reads that file and imports it into a running Canutin v2 server: accounts, assets, their balance histories, and every transaction.
+
+The import is tracked. It shows up under **Settings → Imports** in v2, and a **Revert** button there removes everything it created, so you can try it, look around, and redo it.
+
+## Before you start
+
+- A running Canutin v2 server. See the [README](../README.md) for self-hosting instructions.
+- A regular user account on that server. Sign up in the v2 app first; the import runs as you.
+- Your v1 `.vault` file.
+- [Bun](https://bun.sh) installed on any machine that can reach your server. The script talks to the server over HTTP, so it doesn't need to run on the server itself.
+
+## Run the import
+
+Clone this repo and run the script against your vault:
+
+```bash
+git clone https://github.com/fmaclen/canutin.git
+cd canutin
+bun install
+bun run pb:import /path/to/Canutin.vault \
+  --email you@example.com \
+  --password yourpassword \
+  --pb-url https://canutin-pb.example.com
+```
+
+`--pb-url` is the URL of your server's PocketBase service, the same value as `PUBLIC_PB_URL` in your Docker setup.
+
+Two more options:
+
+- `--currency` sets the currency for everything in the vault, since v1 didn't record one. Defaults to `USD`. A different code must already exist in your v2 currency settings before importing.
+- `--label` names the import in **Settings → Imports**. Defaults to the vault's filename.
+
+Running the script again is safe: rows that already exist are skipped, not duplicated.
+
+## What carries over
+
+- Accounts, with their full balance history.
+- Assets, with their full balance history.
+- All transactions, including excluded ones.
+- Transaction categories and groups, flattened into v2 labels. A transaction categorized as "Groceries" in the "Food & drink" group gets both names as labels.
+- Auto-calculated accounts behave like they did in v1: their balance is computed from the imported transactions rather than from stored statements.
+
+## What doesn't
+
+- Investment details on assets. v1 assets with a symbol and quantity (stocks, crypto) import as plain assets carrying their total market value. v2 tracks investments as securities held inside accounts, which has no v1 equivalent, so positions have to be re-created by hand if you want them in the portfolio.
+- The pending flag on transactions.
+- v1 app settings.
+
+If something looks wrong after importing, revert from **Settings → Imports** and run it again.

--- a/docs/plaid.md
+++ b/docs/plaid.md
@@ -1,0 +1,44 @@
+# Syncing banks with Plaid
+
+Canutin can pull balances and transactions from your bank through [Plaid](https://plaid.com). The integration is optional and off by default. You bring your own Plaid API credentials, so your financial data flows directly between your bank, Plaid, and your own Canutin server.
+
+## Get Plaid credentials
+
+1. Create an account at [dashboard.plaid.com](https://dashboard.plaid.com).
+2. Copy your **client ID** and **secret** from the dashboard's keys page.
+3. Pick an environment. `sandbox` connects to fake banks with test data and works immediately. `production` connects to real banks and requires Plaid's approval, which you request from the dashboard. Plaid's production pricing applies to your own usage.
+
+## Configure Canutin
+
+Set three environment variables on the `pocketbase` service. If you followed the self-hosting setup in the [README](../README.md), create a `.env` file next to your `docker-compose.yml`:
+
+```dotenv
+PLAID_CLIENT_ID=<your-client-id>
+PLAID_SECRET=<your-secret>
+PLAID_ENV=production
+```
+
+`PLAID_ENV` must be exactly `sandbox` or `production` and has no default. Restart the containers after changing it:
+
+```bash
+docker compose up -d
+```
+
+No webhooks or redirect URIs need to be configured on the Plaid side. Bank logins happen inside Plaid's own widget, and Canutin never sees your bank password.
+
+## Link a bank
+
+1. In Canutin, go to **Accounts**, add an account, and choose the option to sign in to your bank.
+2. Plaid's window opens. Choose your bank and sign in.
+3. Canutin then asks you to match each account at the bank to an existing Canutin account, or create new ones.
+
+## Syncing
+
+Linked accounts sync automatically once a day at 06:00 UTC. To sync sooner, go to **Settings → Linked institutions** and click **Sync** on the institution.
+
+The same page lets you unlink an institution. If a bank requires you to sign in again, the connection shows **Reconnect**, which reopens Plaid's window to refresh access.
+
+## Troubleshooting
+
+- Every Plaid action fails and the server responds with `plaid_not_configured`: one of the three environment variables is missing or `PLAID_ENV` has a value other than `sandbox` or `production`. Fix the `.env` file and restart.
+- A connection stops syncing: check **Settings → Linked institutions**. Banks periodically expire access, and the connection will show **Reconnect** when that happens. Connections needing reauthorization are skipped by the nightly sync until you reconnect them.

--- a/scripts/pb-import.ts
+++ b/scripts/pb-import.ts
@@ -1,3 +1,4 @@
+// Migrate a Canutin v1 vault (SQLite) into Canutin v2 through the bulk import API.
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { Database } from 'bun:sqlite';
@@ -11,543 +12,323 @@ function error(msg: string) {
 	console.error(`[pb:import] ERROR: ${msg}`);
 }
 
-function mapBalanceGroup(
-	n: number | null | undefined
-): 'CASH' | 'DEBT' | 'INVESTMENT' | 'OTHER' | undefined {
-	if (n === null || n === undefined) return undefined;
-	switch (Number(n)) {
-		case 0:
-			return 'CASH';
-		case 1:
-			return 'DEBT';
-		case 2:
-			return 'INVESTMENT';
-		case 3:
-			return 'OTHER';
-		default:
-			return undefined;
-	}
+function printUsage() {
+	console.log(`Migrate a Canutin v1 vault into your Canutin v2 account.
+
+Usage:
+  bun run pb:import <vault-path> --email <email> --password <password> [options]
+
+Arguments:
+  <vault-path>          Path to the Canutin v1 .vault file
+
+Options:
+  --email <email>       Email of the Canutin account to import into
+  --password <pass>     Password of that account
+  --pb-url <url>        Canutin server URL (default: $PUBLIC_PB_URL)
+  --currency <code>     Currency of the vault's accounts and assets (default: USD).
+                        Canutin v1 vaults hold a single currency; the code must already
+                        exist in your Canutin currency settings
+  --label <label>       Name for this import, shown in Canutin settings
+                        (default: the vault's filename)
+
+The account must already exist - sign up in Canutin first, then run this.
+Everything imported is tagged as one import, so it can be undone from Canutin settings.`);
 }
 
-function toISODate(d: unknown): string | undefined {
-	if (d === null || d === undefined) return undefined;
-	try {
-		// Handle numeric epoch (seconds or ms) and numeric-like strings
-		if (typeof d === 'number' && Number.isFinite(d)) {
-			const ms = d > 1e12 ? d : d * 1000; // seconds vs ms
-			return formatDateTimeZ(new Date(ms));
-		}
-		const s = String(d).trim();
-		if (!s) return undefined;
-		if (/^\d+$/.test(s)) {
-			const n = Number(s);
-			if (Number.isFinite(n)) {
-				const ms = s.length >= 13 ? n : n * 1000; // 13+ digits -> ms
-				return formatDateTimeZ(new Date(ms));
-			}
-		}
-		// 'YYYY-MM-DD'
-		if (/^\d{4}-\d{2}-\d{2}$/.test(s)) return `${s} 00:00:00.000Z`;
-		// 'YYYY-MM-DD HH:MM:SS' or other parseable strings
-		const dt = new Date(s);
-		if (!isNaN(dt.getTime())) return formatDateTimeZ(dt);
-		return undefined;
-	} catch {
-		return undefined;
-	}
-}
-
-function pad(n: number, w = 2) {
-	return String(n).padStart(w, '0');
-}
-
-function formatDateTimeZ(d: Date): string {
-	// Always format as 'YYYY-MM-DD HH:MM:SS.mmmZ' in UTC
-	const y = d.getUTCFullYear();
-	const m = pad(d.getUTCMonth() + 1);
-	const day = pad(d.getUTCDate());
-	const hh = pad(d.getUTCHours());
-	const mm = pad(d.getUTCMinutes());
-	const ss = pad(d.getUTCSeconds());
-	const ms = pad(d.getUTCMilliseconds(), 3);
-	return `${y}-${m}-${day} ${hh}:${mm}:${ss}.${ms}Z`;
-}
-
-function normalizeDateOr(primary: unknown, fallback?: unknown): string | undefined {
-	return toISODate(primary) ?? toISODate(fallback ?? '') ?? undefined;
-}
-
-type ImportOptions = {
+type Options = {
 	vaultPath: string;
-	email: string | null;
-	password: string | null;
-	name: string | null;
-	pbBaseUrl: string | null;
-	superuserEmail: string | null;
-	superuserPassword: string | null;
+	email: string;
+	password: string;
+	pbUrl: string;
+	currency: string;
+	label: string;
 };
 
-function parseArgs(args: string[]): ImportOptions | null {
+function parseArgs(args: string[]) {
 	const positional: string[] = [];
-	let email: string | null = null;
-	let password: string | null = null;
-	let name: string | null = null;
-	let pbBaseUrl: string | null = null;
-	let superuserEmail: string | null = null;
-	let superuserPassword: string | null = null;
+	const flags = new Map<string, string>();
 
 	for (let i = 0; i < args.length; i += 1) {
 		const arg = args[i];
-
-		if (arg === '--help' || arg === '-h') {
-			return null;
-		}
-
-		if (arg === '--email') {
-			email = args[i + 1] ?? null;
-			i += 1;
-			continue;
-		}
-
-		if (arg === '--password') {
-			password = args[i + 1] ?? null;
-			i += 1;
-			continue;
-		}
-
-		if (arg === '--name') {
-			name = args[i + 1] ?? null;
-			i += 1;
-			continue;
-		}
-
-		if (arg === '--pb-url') {
-			pbBaseUrl = args[i + 1] ?? pbBaseUrl;
-			i += 1;
-			continue;
-		}
-
-		if (arg === '--superuser-email') {
-			superuserEmail = args[i + 1] ?? superuserEmail;
-			i += 1;
-			continue;
-		}
-
-		if (arg === '--superuser-password') {
-			superuserPassword = args[i + 1] ?? superuserPassword;
-			i += 1;
-			continue;
-		}
-
+		if (arg === '--help' || arg === '-h') return null;
 		if (arg.startsWith('--')) {
-			throw new Error(`Unknown option: ${arg}`);
+			const value = args[i + 1];
+			if (value === undefined || value.startsWith('--')) {
+				throw new Error(`Missing value for ${arg}`);
+			}
+			flags.set(arg, value.trim());
+			i += 1;
+			continue;
 		}
-
 		positional.push(arg);
 	}
 
-	if (positional.length < 1) {
-		throw new Error(
-			'Missing required path to .vault file. Example: bun pb:import temp/Canutin.demo.vault --email calypso@example.com --password hunter2'
-		);
+	const known = ['--email', '--password', '--pb-url', '--currency', '--label'];
+	for (const flag of flags.keys()) {
+		if (!known.includes(flag)) throw new Error(`Unknown option: ${flag}`);
 	}
 
-	if (!email?.trim()) {
-		throw new Error('Missing required --email option');
-	}
+	const vaultPath = positional[0];
+	if (!vaultPath) throw new Error('Missing the path to your Canutin v1 .vault file');
 
-	if (!pbBaseUrl?.trim()) {
-		throw new Error('Missing required --pb-url option');
-	}
+	const email = flags.get('--email');
+	if (!email) throw new Error('Missing --email (the Canutin account to import into)');
 
-	if (!superuserEmail?.trim()) {
-		throw new Error('Missing required --superuser-email option');
-	}
+	const password = flags.get('--password');
+	if (!password) throw new Error('Missing --password (the password for that account)');
 
-	if (!superuserPassword?.trim()) {
-		throw new Error('Missing required --superuser-password option');
+	const pbUrl = flags.get('--pb-url') ?? process.env.PUBLIC_PB_URL;
+	if (!pbUrl) throw new Error('Missing --pb-url (the URL of your Canutin server)');
+
+	const currency = (flags.get('--currency') ?? 'USD').toUpperCase();
+	if (!/^[A-Z0-9]{2,10}$/.test(currency)) {
+		throw new Error(`Invalid --currency "${currency}", expected a code like USD or EUR`);
 	}
 
 	return {
-		vaultPath: path.resolve(positional[0]),
-		email: email.trim(),
-		password: password?.trim() ? password.trim() : null,
-		name: name?.trim() ? name.trim() : null,
-		pbBaseUrl: pbBaseUrl.trim(),
-		superuserEmail: superuserEmail.trim(),
-		superuserPassword: superuserPassword.trim()
+		vaultPath: path.resolve(vaultPath),
+		email,
+		password,
+		pbUrl,
+		currency,
+		label: flags.get('--label') || path.basename(vaultPath)
+	} satisfies Options;
+}
+
+// v1 stored balance groups as an ordinal on the Account and Asset tables.
+const BALANCE_GROUPS = ['CASH', 'DEBT', 'INVESTMENT', 'OTHER'];
+
+// v1 timestamps are epoch milliseconds; the import API takes ISO dates.
+function toIsoDate(epochMs: number) {
+	return new Date(epochMs).toISOString();
+}
+
+type VaultRow = { id: number; name: string };
+
+function readVault(vaultPath: string, currency: string) {
+	const db = new Database(vaultPath, { readonly: true });
+
+	const nameById = (rows: VaultRow[]) => new Map(rows.map((row) => [row.id, row.name]));
+	const accountTypes = nameById(db.query('SELECT id, name FROM AccountType').all() as VaultRow[]);
+	const assetTypes = nameById(db.query('SELECT id, name FROM AssetType').all() as VaultRow[]);
+	const categoryGroups = nameById(
+		db.query('SELECT id, name FROM TransactionCategoryGroup').all() as VaultRow[]
+	);
+	const categories = new Map(
+		(
+			db
+				.query('SELECT id, name, transactionCategoryId AS groupId FROM TransactionCategory')
+				.all() as Array<VaultRow & { groupId: number }>
+		).map((row) => [row.id, { name: row.name, groupName: categoryGroups.get(row.groupId) }])
+	);
+
+	const accountRows = db
+		.query(
+			`SELECT id, name, institution, isClosed, isAutoCalculated, isExcludedFromNetWorth,
+			        balanceGroup, accountTypeId
+			 FROM Account ORDER BY id`
+		)
+		.all() as Array<{
+		id: number;
+		name: string;
+		institution: string | null;
+		isClosed: number;
+		isAutoCalculated: number;
+		isExcludedFromNetWorth: number;
+		balanceGroup: number;
+		accountTypeId: number;
+	}>;
+
+	const assetRows = db
+		.query(
+			`SELECT id, name, balanceGroup, isSold, isExcludedFromNetWorth, assetTypeId
+			 FROM Asset ORDER BY id`
+		)
+		.all() as Array<{
+		id: number;
+		name: string;
+		balanceGroup: number;
+		isSold: number;
+		isExcludedFromNetWorth: number;
+		assetTypeId: number;
+	}>;
+
+	const accountBalanceRows = db
+		.query('SELECT accountId, value, createdAt FROM AccountBalanceStatement ORDER BY createdAt')
+		.all() as Array<{ accountId: number; value: number; createdAt: number }>;
+
+	const assetBalanceRows = db
+		.query('SELECT assetId, value, createdAt FROM AssetBalanceStatement ORDER BY createdAt')
+		.all() as Array<{ assetId: number; value: number; createdAt: number }>;
+
+	const transactionRows = db
+		.query(
+			`SELECT description, date, value, isExcluded, categoryId, accountId
+			 FROM "Transaction" ORDER BY id`
+		)
+		.all() as Array<{
+		description: string;
+		date: number;
+		value: number;
+		isExcluded: number;
+		categoryId: number;
+		accountId: number;
+	}>;
+
+	db.close();
+
+	const accountsById = new Map(
+		accountRows.map((row) => [
+			row.id,
+			{
+				name: row.name,
+				institution: row.institution ?? '',
+				balanceGroup: BALANCE_GROUPS[row.balanceGroup],
+				balanceType: accountTypes.get(row.accountTypeId) ?? '',
+				currency,
+				autoCalculated: Boolean(row.isAutoCalculated),
+				closed: Boolean(row.isClosed),
+				excluded: Boolean(row.isExcludedFromNetWorth)
+			}
+		])
+	);
+
+	const assetsById = new Map(
+		assetRows.map((row) => [
+			row.id,
+			{
+				name: row.name,
+				balanceGroup: BALANCE_GROUPS[row.balanceGroup],
+				balanceType: assetTypes.get(row.assetTypeId) ?? '',
+				currency,
+				sold: Boolean(row.isSold),
+				excluded: Boolean(row.isExcludedFromNetWorth)
+			}
+		])
+	);
+
+	// The import API carries one balance snapshot per account/asset entry, so a v1 balance
+	// history becomes one repeated entry per statement. Repeats resolve to the same record
+	// because accounts and assets are deduplicated by name.
+	const accounts = [...accountsById.values()].map((account) => ({ ...account }));
+	for (const row of accountBalanceRows) {
+		const account = accountsById.get(row.accountId);
+		if (!account) continue;
+		accounts.push({ ...account, balance: { value: row.value, asOf: toIsoDate(row.createdAt) } });
+	}
+
+	const assets = [...assetsById.values()].map((asset) => ({ ...asset }));
+	for (const row of assetBalanceRows) {
+		const asset = assetsById.get(row.assetId);
+		if (!asset) continue;
+		assets.push({ ...asset, balance: { marketValue: row.value, asOf: toIsoDate(row.createdAt) } });
+	}
+
+	const transactions = transactionRows.flatMap((row) => {
+		const account = accountsById.get(row.accountId);
+		if (!account) return [];
+		const category = categories.get(row.categoryId);
+		// v1 categories were nested inside a group; v2 labels are flat, so both become labels.
+		// A category named after its own group collapses to a single label.
+		const labels = [...new Set([category?.name, category?.groupName].filter(Boolean))];
+		return [
+			{
+				accountName: account.name,
+				institution: account.institution,
+				balanceGroup: account.balanceGroup,
+				date: toIsoDate(row.date),
+				description: row.description,
+				value: row.value,
+				excluded: Boolean(row.isExcluded),
+				labels
+			}
+		];
+	});
+
+	return {
+		accounts,
+		assets,
+		transactions,
+		vaultCounts: {
+			accounts: accountRows.length,
+			assets: assetRows.length,
+			accountBalances: accountBalanceRows.length,
+			assetBalances: assetBalanceRows.length,
+			transactions: transactionRows.length
+		}
 	};
 }
 
-function printUsage() {
-	log(
-		'Usage: bun pb:import <vault-path> --email <user-email> --pb-url <url> --superuser-email <email> --superuser-password <password> [--password <password>] [--name <display-name>]'
-	);
-	log('If the user does not exist yet, --password is required and the user will be created.');
-}
-
 async function main() {
-	let options: ImportOptions | null;
+	let options: Options | null;
 	try {
 		options = parseArgs(process.argv.slice(2));
-	} catch (err) {
-		error(err instanceof Error ? err.message : 'Failed to parse arguments');
+	} catch (e) {
+		error((e as Error).message);
+		console.log('');
 		printUsage();
 		process.exit(1);
 	}
 
 	if (!options) {
 		printUsage();
-		process.exit(0);
+		return;
 	}
 
-	const { vaultPath, email, password, name, pbBaseUrl, superuserEmail, superuserPassword } =
-		options;
-
 	try {
-		await fs.access(vaultPath);
+		await fs.access(options.vaultPath);
 	} catch {
-		error(`Vault file not found: ${vaultPath}`);
+		error(`No vault file at ${options.vaultPath}`);
 		process.exit(1);
 	}
 
-	log(`Opening SQLite vault: ${vaultPath}`);
-	const db = new Database(vaultPath, { readonly: true });
-
-	// Prepare PocketBase client
-	const pb = new PocketBase(pbBaseUrl);
-
-	log(`Authenticating as superuser at ${pbBaseUrl} ...`);
+	const pb = new PocketBase(options.pbUrl);
 	try {
-		// With PB >=0.23 superusers are a system auth collection
-		await pb.collection('_superusers').authWithPassword(superuserEmail, superuserPassword);
+		await pb.collection('users').authWithPassword(options.email, options.password);
 	} catch (e) {
-		error(`Failed to authenticate: ${(e as Error).message}`);
+		error(`Could not sign in as ${options.email} at ${options.pbUrl}`);
+		error((e as Error).message);
 		process.exit(1);
 	}
 
-	// Ensure target user exists, then import records owned by that user.
-	let ownerId: string | null = null;
+	const { accounts, assets, transactions, vaultCounts } = readVault(
+		options.vaultPath,
+		options.currency
+	);
+	log(
+		`Read ${vaultCounts.accounts} accounts, ${vaultCounts.assets} assets, ${vaultCounts.transactions} transactions, ` +
+			`${vaultCounts.accountBalances + vaultCounts.assetBalances} balance statements from ${path.basename(options.vaultPath)}`
+	);
+
+	log(`Importing into ${options.email} as "${options.label}"`);
+	let result: { recordsFailed: number };
 	try {
-		const existing = await pb
-			.collection('users')
-			.getFirstListItem(`email = ${JSON.stringify(email)}`);
-		ownerId = existing.id;
-		log(`Found target user: ${email} (${ownerId})`);
-	} catch {
-		if (!password) {
-			error(`Target user ${email} does not exist and no --password was provided`);
-			process.exit(1);
-		}
-
-		log(`Creating target user: ${email}`);
-		const created = await pb.collection('users').create({
-			email,
-			name: name ?? undefined,
-			password,
-			passwordConfirm: password
+		result = await pb.send('/api/canutin/import', {
+			method: 'POST',
+			body: { sessionLabel: options.label, accounts, assets, transactions }
 		});
-		ownerId = created.id;
+	} catch (e) {
+		const response = (e as { response?: { error?: string; missingCurrencies?: string[] } })
+			.response;
+		if (response?.missingCurrencies?.length) {
+			error(
+				`Add the currency ${response.missingCurrencies.join(', ')} in Canutin settings, then run this again`
+			);
+		} else {
+			error(`Import failed: ${response?.error ?? (e as Error).message}`);
+		}
+		process.exit(1);
 	}
 
-	// Helpers: upsert by name and cache ids (per-user scope)
-	const balanceTypeIdByName = new Map<string, string>();
-	const txLabelIdByName = new Map<string, string>();
-
-	async function upsertBalanceType(name: string): Promise<string> {
-		const key = name.trim();
-		if (balanceTypeIdByName.has(key)) return balanceTypeIdByName.get(key) as string;
-		try {
-			const existing = await pb
-				.collection('balanceTypes')
-				.getFirstListItem(`name = ${JSON.stringify(key)} && owner = ${JSON.stringify(ownerId)}`);
-			balanceTypeIdByName.set(key, existing.id);
-			return existing.id;
-		} catch {
-			const created = await pb.collection('balanceTypes').create({ name: key, owner: ownerId });
-			balanceTypeIdByName.set(key, created.id);
-			return created.id;
-		}
+	console.log(JSON.stringify(result, null, 2));
+	if (result.recordsFailed) {
+		error(`${result.recordsFailed} records could not be imported - see the server log for details`);
+		process.exit(1);
 	}
-
-	async function upsertTxLabel(name: string): Promise<string> {
-		const key = name.trim();
-		if (txLabelIdByName.has(key)) return txLabelIdByName.get(key) as string;
-		try {
-			const existing = await pb
-				.collection('transactionLabels')
-				.getFirstListItem(`name = ${JSON.stringify(key)} && owner = ${JSON.stringify(ownerId)}`);
-			txLabelIdByName.set(key, existing.id);
-			return existing.id;
-		} catch {
-			const created = await pb
-				.collection('transactionLabels')
-				.create({ name: key, owner: ownerId });
-			txLabelIdByName.set(key, created.id);
-			return created.id;
-		}
-	}
-
-	// Load old reference tables
-	type Ref = { id: number; name: string };
-	const accountTypes = db.query('SELECT id, name FROM AccountType ORDER BY id').all() as Ref[];
-	const legacyAssetCategories = db
-		.query('SELECT id, name FROM AssetType ORDER BY id')
-		.all() as Ref[];
-	const txGroups = db
-		.query('SELECT id, name FROM TransactionCategoryGroup ORDER BY id')
-		.all() as Ref[];
-	const txCategories = db
-		.query('SELECT id, name, transactionCategoryId FROM TransactionCategory ORDER BY id')
-		.all() as Array<Ref & { transactionCategoryId: number }>;
-
-	log(
-		`Found: ${accountTypes.length} AccountType, ${legacyAssetCategories.length} legacy asset categories, ${txGroups.length} Tx Groups, ${txCategories.length} Tx Categories`
-	);
-
-	const accountTypeNameById = new Map<number, string>(accountTypes.map((r) => [r.id, r.name]));
-	const assetCategoryNameById = new Map<number, string>(
-		legacyAssetCategories.map((r) => [r.id, r.name])
-	);
-	const txGroupNameById = new Map<number, string>(txGroups.map((r) => [r.id, r.name]));
-	const txCatNameById = new Map<number, string>(txCategories.map((r) => [r.id, r.name]));
-	const txCatGroupIdByCatId = new Map<number, number>(
-		txCategories.map((r) => [r.id, r.transactionCategoryId])
-	);
-
-	type AccountRow = {
-		id: number;
-		name: string;
-		institution?: string | null;
-		isClosed: number;
-		isAutoCalculated: number;
-		isExcludedFromNetWorth: number;
-		balanceGroup: number;
-		accountTypeId: number | null;
-		createdAt?: string;
-		updatedAt?: string;
-	};
-	const accounts = db
-		.query(
-			'SELECT id,name,institution,isClosed,isAutoCalculated,isExcludedFromNetWorth,balanceGroup,accountTypeId,createdAt,updatedAt FROM Account ORDER BY id'
-		)
-		.all() as AccountRow[];
-
-	type AssetRow = {
-		id: number;
-		name: string;
-		balanceGroup: number;
-		isSold: number;
-		assetCategoryId: number | null;
-		isExcludedFromNetWorth: number;
-		createdAt?: string;
-		updatedAt?: string;
-	};
-	const assets = db
-		.query(
-			'SELECT id,name,balanceGroup,isSold,assetTypeId AS assetCategoryId,isExcludedFromNetWorth,createdAt,updatedAt FROM Asset ORDER BY id'
-		)
-		.all() as AssetRow[];
-
-	type AccBalRow = {
-		id: number;
-		value: number;
-		accountId: number;
-		createdAt?: string;
-		updatedAt?: string;
-	};
-	const accountBalances = db
-		.query(
-			'SELECT id,value,accountId,createdAt,updatedAt FROM AccountBalanceStatement ORDER BY createdAt, id'
-		)
-		.all() as AccBalRow[];
-
-	type AstBalRow = {
-		id: number;
-		value: number;
-		cost?: number | null;
-		assetId: number;
-		createdAt?: string;
-		updatedAt?: string;
-	};
-	const assetBalances = db
-		.query(
-			'SELECT id,value,cost,assetId,createdAt,updatedAt FROM AssetBalanceStatement ORDER BY createdAt, id'
-		)
-		.all() as AstBalRow[];
-
-	type TxRow = {
-		id: number;
-		description: string;
-		date: string;
-		value: number;
-		isExcluded: number;
-		isPending: number;
-		categoryId: number | null;
-		accountId: number;
-		createdAt?: string;
-		updatedAt?: string;
-	};
-	const transactions = db
-		.query(
-			'SELECT id,description,date,value,isExcluded,isPending,categoryId,accountId,createdAt,updatedAt FROM "Transaction" ORDER BY id'
-		)
-		.all() as TxRow[];
-
-	log(
-		`Rows: accounts=${accounts.length}, assets=${assets.length}, accountBalances=${accountBalances.length}, assetBalances=${assetBalances.length}, transactions=${transactions.length}`
-	);
-
-	// Create accounts and assets first
-	const pbAccountIdByOldId = new Map<number, string>();
-	const pbAssetIdByOldId = new Map<number, string>();
-
-	for (const a of accounts) {
-		const autoDate = a.isAutoCalculated
-			? (normalizeDateOr(a.updatedAt, a.createdAt) ?? toISODate(new Date().toISOString()))
-			: undefined;
-
-		const excludedDate = a.isExcludedFromNetWorth
-			? (normalizeDateOr(a.createdAt, a.updatedAt) ?? toISODate(new Date().toISOString()))
-			: undefined;
-
-		const data: Record<string, unknown> = {
-			name: a.name,
-			institution: a.institution ?? undefined,
-			balanceGroup: mapBalanceGroup(a.balanceGroup),
-			// If closed, prefer updatedAt then createdAt; fallback to now for determinism
-			closed: a.isClosed
-				? (normalizeDateOr(a.updatedAt, a.createdAt) ?? toISODate(new Date().toISOString()))
-				: undefined,
-			// For auto-calculated accounts, ensure a truthy RFC date even if updatedAt is null
-			autoCalculated: autoDate,
-			// Legacy flag maps to datetime; prefer creation, fallback update, then now
-			excluded: excludedDate,
-			owner: ownerId
-		};
-
-		// BalanceType in PB is used to indicate computation mode such as "Auto-calculated".
-		// If the legacy account is marked auto-calculated, set BalanceType to "Auto-calculated".
-		// Otherwise, fallback to the legacy account type name if present.
-		const typeName = a.accountTypeId ? accountTypeNameById.get(a.accountTypeId) : undefined;
-		if (a.isAutoCalculated) {
-			data.balanceType = await upsertBalanceType('Auto-calculated');
-		} else if (typeName) {
-			data.balanceType = await upsertBalanceType(typeName);
-		}
-
-		try {
-			const created = await pb.collection('accounts').create(data);
-			pbAccountIdByOldId.set(a.id, created.id);
-		} catch (e) {
-			error(`Failed to create account: ${JSON.stringify(data)}`);
-			throw e;
-		}
-	}
-
-	for (const a of assets) {
-		const categoryName = a.assetCategoryId
-			? assetCategoryNameById.get(a.assetCategoryId)
-			: undefined;
-
-		const data: Record<string, unknown> = {
-			name: a.name,
-			balanceGroup: mapBalanceGroup(a.balanceGroup),
-			// If sold, prefer updatedAt then createdAt; fallback to now for determinism
-			sold: a.isSold
-				? (normalizeDateOr(a.updatedAt, a.createdAt) ?? toISODate(new Date().toISOString()))
-				: undefined,
-			excluded: a.isExcludedFromNetWorth ? toISODate(a.updatedAt) : undefined,
-			owner: ownerId
-		};
-		if (categoryName) data.balanceType = await upsertBalanceType(categoryName);
-
-		try {
-			const created = await pb.collection('assets').create(data);
-			pbAssetIdByOldId.set(a.id, created.id);
-		} catch (e) {
-			error(`Failed to create asset: ${JSON.stringify(data)}`);
-			throw e;
-		}
-	}
-
-	// Create balance records with direct relations to parent
-	for (const s of accountBalances) {
-		const pbAccountId = pbAccountIdByOldId.get(s.accountId);
-		if (!pbAccountId) continue;
-		const balData = {
-			account: pbAccountId,
-			value: s.value,
-			asOf: toISODate(s.createdAt),
-			owner: ownerId
-		};
-		try {
-			await pb.collection('accountBalances').create(balData);
-		} catch (e) {
-			error(`Failed to create accountBalance: ${JSON.stringify(balData)}`);
-			throw e;
-		}
-	}
-
-	for (const s of assetBalances) {
-		const pbAssetId = pbAssetIdByOldId.get(s.assetId);
-		if (!pbAssetId) continue;
-		const balData = {
-			asset: pbAssetId,
-			marketValue: s.value,
-			bookValue: s.cost || undefined,
-			asOf: toISODate(s.createdAt),
-			owner: ownerId
-		};
-		try {
-			await pb.collection('assetBalances').create(balData);
-		} catch (e) {
-			error(`Failed to create assetBalance: ${JSON.stringify(balData)}`);
-			throw e;
-		}
-	}
-
-	// Create transactions with direct account relation
-	for (const t of transactions) {
-		const pbAccountId = pbAccountIdByOldId.get(t.accountId);
-		if (!pbAccountId) continue;
-
-		const labels: string[] = [];
-		if (t.categoryId != null) {
-			const catName = txCatNameById.get(t.categoryId);
-			if (catName) labels.push(await upsertTxLabel(catName));
-			const groupId = txCatGroupIdByCatId.get(t.categoryId);
-			if (groupId) {
-				const groupName = txGroupNameById.get(groupId);
-				if (groupName) labels.push(await upsertTxLabel(groupName));
-			}
-		}
-
-		const exDate = t.isExcluded
-			? (normalizeDateOr(t.updatedAt, t.date) ?? toISODate(new Date().toISOString()))
-			: undefined;
-
-		const data: Record<string, unknown> = {
-			account: pbAccountId,
-			description: t.description,
-			date: normalizeDateOr(t.date, t.createdAt ?? t.updatedAt),
-			value: t.value,
-			excluded: exDate,
-			labels,
-			owner: ownerId
-		};
-		try {
-			await pb.collection('transactions').create(data);
-		} catch (e) {
-			error(`Failed to create transaction: ${JSON.stringify(data)}`);
-			throw e;
-		}
-	}
-
-	log('Import complete.');
+	log('Import complete. To undo it, revert the import from Canutin settings.');
 }
 
 main().catch((e) => {
-	error((e as Error).stack || (e as Error).message);
+	error((e as Error).message);
 	process.exit(1);
 });


### PR DESCRIPTION
- Reworks `pb-import.ts` to send a v1 vault as one payload through `/api/canutin/import`, fixing the missing required currency field and gaining revert and idempotent re-runs. Verified against a real v1 vault: all accounts, assets, transactions, and balance statements match, and revert removes everything.
- Adds `docs/` with three guides canutin.com can link to: migrating from a v1 vault, Plaid setup, and using AI agents via the served skill URL.
- Rewrites the README for public v2 users: description, demo link, feature list, and a self-host snippet that now includes `ORIGIN` plus a section on serving behind a domain. It pulls `:latest`, so it should merge as part of the v2 launch.
- Restores the Apache-2.0 LICENSE byte-for-byte from git history and corrects the Docker image's AGPL-3.0 label to Apache-2.0.
- The migration guide's CLI flags and every UI label referenced in the docs were checked against the actual script usage output and `messages/en.json`.

Closes #430