### PR TITLE
fix: render error pages on the splash screen layout

### DIFF
--- a/e2e/error-pages.test.ts
+++ b/e2e/error-pages.test.ts
@@ -20,8 +20,9 @@ test('displays error 404 page when visiting non-existent route', async ({ page }
 	// Explicit purpose of this test is direct-URL 404 behavior for a route the UI never links to
 	await page.goto('/this-route-does-not-exist');
 	await expect(page).toHaveURL('/this-route-does-not-exist');
-	await expect(page.getByText('Error 404')).toBeVisible();
-	await expect(page.getByText('Not Found')).toBeVisible();
+	await expect(page.getByText('404', { exact: true })).toBeVisible();
+	await expect(page.getByText("There's nothing at this address")).toBeVisible();
+	await expect(page.getByRole('link', { name: 'go back' })).toBeVisible();
 });
 
 test('displays error 500 page when server error occurs', async ({ page }) => {
@@ -32,12 +33,12 @@ test('displays error 500 page when server error occurs', async ({ page }) => {
 
 	await signIn(page, user.email);
 	await expect(page).toHaveURL('/big-picture');
-	await expect(page.getByText('Error 500')).not.toBeVisible();
+	await expect(page.getByText('500', { exact: true })).not.toBeVisible();
 
 	// Explicit purpose of this test is direct-URL 500 behavior; the dev-only error route
 	// has no UI link
 	await page.goto('/dev/error-500');
 	await expect(page).toHaveURL('/dev/error-500');
-	await expect(page.getByText('Error 500')).toBeVisible();
+	await expect(page.getByText('500', { exact: true })).toBeVisible();
 	await expect(page.getByText('Test server error for playwright')).toBeVisible();
 });

--- a/messages/en.json
+++ b/messages/en.json
@@ -419,6 +419,8 @@
 	"pagination_more_label": "More pages",
 	"pagination_navigation_label": "Pagination",
 	"error_title": "Error {status}",
+	"error_not_found_description": "There's nothing at this address,",
+	"error_link_back": "go back",
 	"error_connection_failed": "Can't connect to the database server",
 	"error_subscription_failed": "Lost connection to live updates",
 	"error_auth_failed": "Your session has expired",

--- a/messages/es.json
+++ b/messages/es.json
@@ -419,6 +419,8 @@
 	"pagination_more_label": "Más páginas",
 	"pagination_navigation_label": "Paginación",
 	"error_title": "Error {status}",
+	"error_not_found_description": "No hay nada en esta dirección,",
+	"error_link_back": "regresa",
 	"error_connection_failed": "No se pudo conectar al servidor de datos",
 	"error_subscription_failed": "Se perdió la conexión a las actualizaciones en vivo",
 	"error_auth_failed": "Tu sesión ha expirado",

--- a/src/lib/components/splash-screen.svelte
+++ b/src/lib/components/splash-screen.svelte
@@ -7,14 +7,16 @@
 	import GuestBackdrop from '$lib/components/guest-backdrop.svelte';
 	import { m } from '$lib/paraglide/messages';
 
-	// Without a body the screen is a loading state. The brand header only links out where leaving
-	// the app is a sensible destination, which is not the case once the user is signed in. Guest
-	// routes already paint the backdrop in their layout, so they opt out of a second one.
+	// Without a body the screen is a loading state; overlays that bring their own spinner (Plaid
+	// Link) opt out of ours. The brand header links to `href` when given and is plain branding
+	// otherwise. Guest routes already paint the backdrop in their layout, so they opt out of a
+	// second one.
 	let {
-		linked = true,
+		href,
 		backdrop = true,
+		spinner = true,
 		children
-	}: { linked?: boolean; backdrop?: boolean; children?: Snippet } = $props();
+	}: { href?: string; backdrop?: boolean; spinner?: boolean; children?: Snippet } = $props();
 </script>
 
 {#snippet brand()}
@@ -26,8 +28,8 @@
 	<GuestBackdrop />
 {/if}
 <div class="relative flex min-h-dvh w-full flex-col items-center px-6">
-	{#if linked}
-		<a href="https://canutin.com" aria-label={m.app_name()} class="flex items-center gap-2.5 py-8">
+	{#if href}
+		<a {href} aria-label={m.app_name()} class="flex items-center gap-2.5 py-8">
 			{@render brand()}
 		</a>
 	{:else}
@@ -39,7 +41,7 @@
 		<div class="mx-auto flex w-full max-w-sm flex-col gap-6">
 			{#if children}
 				{@render children()}
-			{:else}
+			{:else if spinner}
 				<div class="flex justify-center">
 					<LoaderCircleIcon class="text-muted-foreground size-8 animate-spin" />
 				</div>

--- a/src/routes/(app)/accounts/link/+page@.svelte
+++ b/src/routes/(app)/accounts/link/+page@.svelte
@@ -156,4 +156,4 @@
 	<title>{getPageTitle(m.accounts_link_page_title())}</title>
 </svelte:head>
 
-<SplashScreen linked={false} />
+<SplashScreen spinner={false} />

--- a/src/routes/(guest)/demo/+page.svelte
+++ b/src/routes/(guest)/demo/+page.svelte
@@ -32,4 +32,4 @@
 	}
 </script>
 
-<SplashScreen backdrop={false} linked={false} />
+<SplashScreen backdrop={false} />

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { page } from '$app/state';
+	import Link from '$lib/components/link.svelte';
 	import { getPageTitle } from '$lib/components/page';
-	import * as Card from '$lib/components/ui/card/index.js';
+	import SplashScreen from '$lib/components/splash-screen.svelte';
 	import { m } from '$lib/paraglide/messages';
 </script>
 
@@ -9,11 +11,18 @@
 	<title>{getPageTitle(m.error_title({ status: page.status }))}</title>
 </svelte:head>
 
-<div class="flex h-screen w-full items-center justify-center px-4">
-	<Card.Root class="mx-auto w-full max-w-sm">
-		<Card.Header>
-			<Card.Title class="text-2xl">{m.error_title({ status: page.status })}</Card.Title>
-			<Card.Description>{page.error?.message}</Card.Description>
-		</Card.Header>
-	</Card.Root>
-</div>
+<!-- "/" lands on the big picture when signed in and the sign-in page when not, so both the brand
+     header and the description link defer to it. -->
+<SplashScreen href={resolve('/')}>
+	<div class="flex flex-col gap-3 text-center">
+		<h1 class="text-5xl leading-none font-bold">{page.status}</h1>
+		{#if page.status === 404}
+			<p class="text-muted-foreground text-sm">
+				{m.error_not_found_description()}
+				<Link href={resolve('/')}>{m.error_link_back()}</Link>
+			</p>
+		{:else}
+			<p class="text-muted-foreground text-sm">{page.error?.message}</p>
+		{/if}
+	</div>
+</SplashScreen>

--- a/src/routes/setup-splash.svelte
+++ b/src/routes/setup-splash.svelte
@@ -19,7 +19,7 @@
 {/snippet}
 
 {#if status === 'needs-setup'}
-	<SplashScreen>
+	<SplashScreen href="https://canutin.com">
 		<div class="flex flex-col gap-1.5 text-center">
 			<h1 class="text-2xl leading-none font-semibold">{m.setup_title()}</h1>
 			<p class="text-muted-foreground text-sm">{m.setup_description()}</p>
@@ -27,7 +27,7 @@
 		{@render serverRow()}
 	</SplashScreen>
 {:else if status === 'unreachable'}
-	<SplashScreen>
+	<SplashScreen href="https://canutin.com">
 		<div class="flex flex-col gap-1.5 text-center">
 			<h1 class="text-2xl leading-none font-semibold">{m.setup_unreachable_title()}</h1>
 			<p class="text-muted-foreground text-sm">{m.setup_unreachable_description()}</p>
@@ -35,5 +35,5 @@
 		{@render serverRow()}
 	</SplashScreen>
 {:else}
-	<SplashScreen />
+	<SplashScreen href="https://canutin.com" />
 {/if}


### PR DESCRIPTION
- The root error page now renders on the shared `SplashScreen` layout instead of a bare card
- The 404 shows a large status code and friendlier copy, with a link back to `/` that lands on the big picture or sign-in depending on auth state
- The splash screen brand header is clickable via a new `href` prop; the setup screen keeps linking to canutin.com, the error page links to `/`
- The Plaid link page disables the splash spinner so it no longer doubles up with Plaid's own loading overlay
- New copy is localized in English and Spanish, and the error page e2e assertions match the new text

No linked issue (confirmed by user)