### PR TITLE
feat: add configurable Plausible analytics

### DIFF
--- a/.agents/skills/deployment/SKILL.md
+++ b/.agents/skills/deployment/SKILL.md
@@ -51,6 +51,13 @@ Minimum required at runtime:
 
 - `PUBLIC_PB_URL` — URL the frontend uses to reach PocketBase (may be the same host as the SvelteKit server or a dedicated subdomain)
 
+Optional Plausible analytics variables for the SvelteKit container:
+
+- `PUBLIC_PLAUSIBLE_DOMAIN` — site domain registered in Plausible
+- `PUBLIC_PLAUSIBLE_SCRIPT_URL` — full URL of the Plausible tracker script
+
+Analytics loads only when both the domain and script URL are set.
+
 At build time the image takes one optional build arg:
 
 - `APP_VERSION` — the version the app displays in Settings. Defaults to `package.json`'s `version`; the release workflow passes the freshly published version because the Docker build checks out the commit before semantic-release bumps it.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ services:
       - '42069:42069'
     environment:
       PUBLIC_PB_URL: ${PUBLIC_PB_URL:-http://localhost:42070}
+      PUBLIC_PLAUSIBLE_DOMAIN: ${PUBLIC_PLAUSIBLE_DOMAIN:-}
+      PUBLIC_PLAUSIBLE_SCRIPT_URL: ${PUBLIC_PLAUSIBLE_SCRIPT_URL:-}
       ORIGIN: ${ORIGIN:-http://localhost:42069}
     depends_on:
       - pocketbase
@@ -85,6 +87,15 @@ PUBLIC_PB_URL=https://canutin-pb.example.com
 ### Bank syncing
 
 To sync balances and transactions from your bank, add your Plaid credentials to the same `.env` file. See the [Plaid guide](docs/plaid.md).
+
+### Analytics
+
+Plausible analytics is disabled by default. To enable it, add the site domain and script URL from your Plausible installation to the same `.env` file:
+
+```dotenv
+PUBLIC_PLAUSIBLE_DOMAIN=canutin.example.com
+PUBLIC_PLAUSIBLE_SCRIPT_URL=https://plausible.example.com/js/script.js
+```
 
 ## Documentation
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -22,6 +22,8 @@ services:
     environment:
       PUBLIC_PB_URL: 'https://pb.canutin.com'
       PUBLIC_DEMO_ENABLED: 'true'
+      PUBLIC_PLAUSIBLE_DOMAIN: ${PUBLIC_PLAUSIBLE_DOMAIN:-}
+      PUBLIC_PLAUSIBLE_SCRIPT_URL: ${PUBLIC_PLAUSIBLE_SCRIPT_URL:-}
       ORIGIN: 'https://demo.canutin.com'
     depends_on:
       - pocketbase

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,8 @@ services:
       HOST: '0.0.0.0'
       PORT: '42069'
       PUBLIC_PB_URL: 'http://localhost:42070'
+      PUBLIC_PLAUSIBLE_DOMAIN: ${PUBLIC_PLAUSIBLE_DOMAIN:-}
+      PUBLIC_PLAUSIBLE_SCRIPT_URL: ${PUBLIC_PLAUSIBLE_SCRIPT_URL:-}
     depends_on:
       - pocketbase
     restart: unless-stopped

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,6 +3,7 @@
 
 	import { ModeWatcher } from 'mode-watcher';
 
+	import { env } from '$env/dynamic/public';
 	import { browser } from '$app/environment';
 	import favicon from '$lib/assets/favicon.png';
 	import { setAuthContext } from '$lib/auth.svelte';
@@ -41,6 +42,13 @@
 <svelte:head>
 	<link rel="icon" href={favicon} />
 	<title>Canutin</title>
+	{#if env.PUBLIC_PLAUSIBLE_DOMAIN && env.PUBLIC_PLAUSIBLE_SCRIPT_URL}
+		<script
+			async
+			data-domain={env.PUBLIC_PLAUSIBLE_DOMAIN}
+			src={env.PUBLIC_PLAUSIBLE_SCRIPT_URL}
+		></script>
+	{/if}
 </svelte:head>
 
 <ModeWatcher />


### PR DESCRIPTION
> [!WARNING]
> This PR adds new environment variables. Add `PUBLIC_PLAUSIBLE_DOMAIN` and `PUBLIC_PLAUSIBLE_SCRIPT_URL` to the deployment before merging.

- Adds an optional Plausible tracker to the global app layout
- Keeps analytics disabled unless both runtime settings are present
- Passes the settings through local and production Docker Compose setups
- Documents self-hosted Plausible configuration for users and deployers

No linked issue (confirmed by user)