### PR TITLE
fix: align release metadata and updater docs

### DIFF
--- a/.agents/skills/deployment/SKILL.md
+++ b/.agents/skills/deployment/SKILL.md
@@ -34,11 +34,11 @@ Handled by semantic-release via the release workflow. Conventional commits drive
 - `fix:` → patch
 - `feat!:` / `BREAKING CHANGE:` → major
 
-See [code-quality.md](../code-quality/SKILL.md#commit-messages) for the full type list.
+See [commits and PRs](../commits-and-prs/SKILL.md#type-prefix-decides-whether-the-change-deploys) for the supported types.
 
 ## Updates
 
-Every release publishes a new image, but nothing in this repo updates a running deployment. Each host decides when to pull, and how it does that is host configuration, not repo configuration. The README documents the manual `docker compose pull` and an optional Watchtower service for anyone who wants updates applied automatically.
+Every release publishes a new image, but nothing in this repo updates a running deployment. Each host decides when to pull, and how it does that is host configuration, not repo configuration. The README documents the manual `docker compose pull` and an optional maintained Watchtower fork for anyone who wants updates applied automatically.
 
 New environment variables must stay optional with a safe default, because a host that pulls unattended gets the new image without anyone touching its `.env`. A variable that cannot degrade gracefully belongs in a breaking-change release, where the notes call it out.
 
@@ -47,7 +47,7 @@ New environment variables must stay optional with a safe default, because a host
 At runtime the container:
 
 1. Starts the PocketBase binary (with the project's compiled Go hooks) on `:42070`
-2. Starts the SvelteKit Node adapter on `:3000` (or whatever the compose file maps)
+2. Starts the SvelteKit Node adapter on `:42069` (or whatever `PORT` sets)
 3. Uses `PUBLIC_PB_URL` to point the frontend at the in-container PocketBase
 
 ## Environment Variables
@@ -65,7 +65,7 @@ Analytics loads only when both the domain and script URL are set.
 
 At build time the image takes one optional build arg:
 
-- `APP_VERSION` — the version the app displays in Settings. Defaults to `package.json`'s `version`; the release workflow passes the freshly published version because the Docker build checks out the commit before semantic-release bumps it.
+- `APP_VERSION` — the version written to the runtime `package.json` and displayed in Settings. Defaults to `package.json`'s `version`; the release workflow passes the freshly published version because the Docker build checks out the commit before semantic-release bumps it.
 
 Additional variables depend on your deployment target and any custom Go hooks you've added. Check `.env.example` if one exists; otherwise inspect the compose files.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,8 @@ COPY . .
 ARG APP_VERSION
 ENV APP_VERSION=$APP_VERSION
 ENV DOCKER_BUILD=true
-RUN bun run build
+RUN if [ -n "$APP_VERSION" ]; then bun pm pkg set version="$APP_VERSION"; fi \
+	&& bun run build
 
 FROM node:22-slim
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ docker compose pull && docker compose up -d
 
 Settings shows the version you are running and tells you when a newer one is available, so nothing checks for updates unless you open that page.
 
-To update automatically instead, add [Watchtower](https://containrrr.dev/watchtower/) to your `docker-compose.yml`, and label the two services it should watch so the rest of the host is left alone:
+To update automatically instead, add [Watchtower](https://watchtower.nickfedor.com/) to your `docker-compose.yml`, and label the two services it should watch so the rest of the host is left alone:
 
 ```yaml
 services:
@@ -109,14 +109,14 @@ services:
     # ...rest of the service
 
   watchtower:
-    image: containrrr/watchtower:1.7.1
+    image: nickfedor/watchtower:1.21.2
     command: ['--cleanup', '--label-enable', '--interval', '86400']
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     restart: unless-stopped
 ```
 
-Watchtower checks once a day and recreates a container when its image changes.
+This actively maintained Watchtower fork supports Docker Engine 29 through Docker API version negotiation. It checks once a day and recreates a container when its image changes. The original [Containrrr project](https://github.com/containrrr/watchtower) is archived.
 
 Updates apply database migrations on start, so take a copy of the `canutin-data` volume if you want to be able to roll back.
 


### PR DESCRIPTION
- Stamp the published release version into the runtime package metadata before the image build.
- Keep Settings and `/app/package.json` aligned in tagged images.
- Replace the archived Watchtower image with the maintained v1.21.2 fork that negotiates Docker Engine 29 API versions.
- Bring the deployment skill in line with the release build and runtime ports.

Closes #441