### PR TITLE
fix: keep realtime stores stale until a refetch commits

### DIFF
--- a/.agents/skills/realtime/SKILL.md
+++ b/.agents/skills/realtime/SKILL.md
@@ -9,9 +9,13 @@ description: PocketBase realtime subscriptions, debouncing, subscription lifecyc
 
 PocketBase realtime subscriptions drive live data updates. Context stores in `src/lib/*.svelte.ts`
 subscribe to collection changes and refresh UI state accordingly. Every realtime store follows one
-model: **realtime events and reconnects are pure invalidation signals** — each schedules a debounced,
-latest-request-wins full refetch, and the fresh snapshot replaces the whole cache. Events are never
-patched into local state.
+model: **realtime events and reconnects are pure invalidation signals** — each marks the store stale
+and schedules a debounced, latest-request-wins full refetch, and the fresh snapshot replaces the
+whole cache. Events are never patched into local state.
+
+Staleness is **durable**: a store that missed an update stays marked stale until a refetch actually
+commits. A refetch that fails is never discarded — it keeps the flag and retries on a backoff. No
+signal carries correctness on its own; signals only mark stores stale and poke their retries.
 
 ## Store sync contract
 
@@ -37,28 +41,36 @@ sync, and only it invalidates.
 ### The seven obligations
 
 Every realtime store must satisfy all seven. `src/lib/securities.svelte.ts` is the reference shape;
-`src/lib/realtime-sync.ts` holds the two canonical helpers (`RequestSequence`, `Debouncer`).
+`src/lib/realtime-sync.ts` holds the one canonical helper, `StaleSync`.
 
 1. **Subscribe before the initial fetch.** Subscribe in the `init()` effect _before_ issuing the first
    refresh, so no event is missed during the fetch window. The initial fetch is guarded by `userId`.
-2. **Event → debounced invalidate.** A realtime event calls `invalidate()`, which schedules the
-   refetch through the shared `Debouncer` (200ms trailing). Bursts coalesce to one refetch.
-3. **Reconnect → same invalidate.** Register one `registerRealtimeReconnect(() => this.invalidate())`
-   callback per store so a restored connection triggers the identical corrective refetch. The
-   registry decides _when_ that fires — see "Connection recovery" below.
-4. **Latest-request-wins commit.** Take a `RequestSequence` token with `sequence.next()` before the
-   await; on _every_ path that touches state — the success commit, `catch`, and `finally` — re-check
-   both `sequence.isCurrent(token)` and `userId === auth.currentUserId` and bail if either fails. This
-   is what makes an event arriving mid-fetch safe: the stale in-flight fetch is discarded and the
-   follow-up refetch wins.
+2. **Event → `sync.invalidate()`.** A realtime event marks the store stale and schedules the refetch
+   on the shared 200ms trailing debounce. Bursts coalesce to one refetch.
+3. **One `StaleSync` per independently-stale collection, registered with the registry.** Construct it
+   with `new StaleSync(pb, context, operation, (token) => this.refreshAll(token))` and register it via
+   `pb.registerRealtimeSync(sync)`, so a dropped socket marks it stale and a restored one retries it.
+   Most stores need exactly one; add a second only when two collections go stale independently
+   (`transactions.svelte.ts` keeps its label dictionary separate, because a transaction mutation can
+   never change labels).
+4. **Latest-request-wins commit.** The refresh function receives the run's token; on _every_ path that
+   touches state — the success commit and any `finally` — re-check both `sync.isCurrent(token)` and
+   `userId === auth.currentUserId` and bail if either fails. This is what makes an event arriving
+   mid-fetch safe: the stale in-flight fetch is discarded and the follow-up refetch wins.
+   **The refresh must throw on failure** — never swallow the error. `StaleSync` catches it, routes it
+   through `pb.handleConnectionError`, keeps the store stale and retries. A superseded run is dropped
+   without re-marking, because the newer run owns the outcome.
 5. **Whole-cache replace, never event-payload patching.** A refresh replaces the entire cache from the
    fresh snapshot. Never upsert, merge, or read `e.record` into state. Deletes and cascades are handled
    for free — the removed rows are simply absent from the next snapshot.
-6. **Complete dispose.** `dispose()` must: cancel the debounce, unregister _both_ the teardown and the
-   reconnect callback, unsubscribe the specific collection topics (never `realtime.unsubscribe()`), and
-   bump the sequence to supersede any in-flight refresh.
+6. **Complete dispose.** `dispose()` must: call `sync.cancel()` (cancels the pending run, supersedes
+   any in-flight refresh, clears the flag), unregister _both_ the teardown callback and the sync, and
+   unsubscribe the specific collection topics (never `realtime.unsubscribe()`).
 7. **`isLoading` lives only in `init()`.** Set it `true` when the effect starts loading for a user and
    `false` on the guarded commit; invalidations refetch silently.
+
+A user's own write, or an initial load, calls `sync.refreshNow()`: it skips the debounce, and a
+successful run clears the stale flag just like a scheduled one.
 
 ### Auth is the sole exemption
 
@@ -69,37 +81,38 @@ it into the contract.
 
 ## Connection recovery
 
-Reference: `src/lib/pocketbase.svelte.ts` (`registerRealtimeReconnect`, `recoverRealtime`).
+Reference: `src/lib/pocketbase.svelte.ts` (`registerRealtimeSync`, `probeBackend`).
 
 **EventSource has no liveness detection.** A dropped network or a slept laptop routinely leaves the
 socket in `readyState === OPEN` forever: no `error` event, no `onDisconnect`, no `PB_CONNECT`, and
 therefore no reconnect from the SDK — which only reconnects on a transport error. The socket can even
-keep delivering events while the network is down, and every refetch they schedule fails and is
-discarded (stores have no retry). A session in that state stays stale indefinitely. The SDK's
+keep delivering events while the network is down, and every refetch they schedule fails. The SDK's
 reconnect path is real but covers only the cases where the transport actually errors.
 
-So recovery has **three triggers**, all funneled through the registry:
+That is why staleness is durable rather than trigger-driven: a failed refetch keeps the store marked
+stale and retries on its own backoff (first at ~1s, doubling, capped at 30s, paused while the tab is
+hidden). The registry's triggers only make convergence _faster_; none of them is load-bearing for
+correctness.
 
-1. `PB_CONNECT` after an `onDisconnect` with active subscriptions — the SDK's own path.
-2. `window` `online` — the network came back.
-3. `document` `visibilitychange` → visible — covers sleep/wake and long-backgrounded tabs, which
-   `online` alone misses. A hidden tab is deliberately left alone; this trigger picks it up when the
-   user returns.
+- **`onDisconnect` with active subscriptions → mark every registered store stale.** The moment the
+  socket drops, everything is possibly stale, and the flag survives until a refetch commits.
+- **`PB_CONNECT` → retry the stale stores.** The most precise "backend is reachable again" signal
+  there is. A store that is not stale ignores it, so the initial connect costs nothing.
+- **`window` `online` → retry the stale stores**, and reset their backoff — the network just changed.
+- **`document` `visibilitychange` → visible → same.** Covers sleep/wake and long-backgrounded tabs,
+  which `online` alone misses; retries are paused while hidden and picked back up here.
 
-Triggers 2 and 3 are browser-only, so they are registered behind `browser` from `$app/environment`.
+The last two are browser-only, so they are registered behind `browser` from `$app/environment`.
 
-Recovery is **latched, not fire-and-forget**. A refetch issued the instant a trigger fires can still
-hit an unusable network (`online` precedes real connectivity), and a store's failed refetch vanishes.
-So the registry probes `health.check()` on a bounded backoff and fires the registered callbacks only
-once the backend actually answers; after the last delay it gives up and waits for the next trigger,
-so an hour offline costs a handful of probes rather than a hot loop. A single `_recovering` flag
-coalesces the burst — SDK reconnect, `online`, and `visibilitychange` usually arrive together — into
-one round of invalidations.
+An `online` event precedes real connectivity, so a retry round asks `pb.probeBackend()` first: one
+small `health.check` answers for every store, so a tick while the backend is down costs one request
+instead of a doomed refetch per store. It is a **gate the retry awaits, not a latch** — marking a
+store stale is idempotent, so triggers arriving mid-round coalesce for free and none can be dropped.
 
-Testing this: dispatching an `error` event on the EventSource only exercises trigger 1 — it injects
-the very signal whose absence is the real-world failure. A genuine offline needs CDP
+Testing this: dispatching an `error` event on the EventSource only exercises the SDK's own path — it
+injects the very signal whose absence is the real-world failure. A genuine offline needs CDP
 (`Network.emulateNetworkConditions`); Playwright's `context.setOffline()` tears the socket down and
-so exercises trigger 1 as well. Both cases are covered in `e2e/shared-records.test.ts`.
+so exercises the SDK path as well. Both cases are covered in `e2e/shared-records.test.ts`.
 
 ## Server-side debouncing (Go hooks)
 
@@ -125,8 +138,10 @@ refetches, not one per row.
   the sync/projection split above
 - **Dropping a mid-flight event as "already fetching"** — obligations 2 and 4 together require a
   follow-up refetch so the newer server state wins
-- **Treating the SDK's reconnect as the whole recovery story** — it never fires when the socket stays
-  OPEN, which is the common real-world drop; the browser triggers are part of the contract
+- **Swallowing a refresh failure** — a discarded refetch is exactly how a store goes quietly stale
+  forever; let it throw so the sync keeps the flag and retries
+- **Treating a signal as correctness** — the SDK's reconnect never fires when the socket stays OPEN,
+  and `online` fires before the network works. Signals only mark and poke; the durable flag decides
 - **`realtime.unsubscribe()`** — kills ALL subscriptions; unsubscribe the specific collection topics
 - **No debouncing** — causes UI flicker and excessive API calls during bulk operations
 

--- a/src/lib/account-cashflow.svelte.ts
+++ b/src/lib/account-cashflow.svelte.ts
@@ -7,9 +7,7 @@ import { getExchangeRatesContext } from './exchange-rates.svelte';
 import { logError } from './logger';
 import { AccountSharesPerspectiveOptions, type TransactionsResponse } from './pocketbase.schema';
 import type { PocketBaseContext } from './pocketbase.svelte';
-import { Debouncer, RequestSequence } from './realtime-sync';
-
-const DEBOUNCE_MS = 200;
+import { StaleSync } from './realtime-sync';
 
 class AccountCashflowContext {
 	isLoading: boolean = $state(true);
@@ -43,8 +41,7 @@ class AccountCashflowContext {
 	private _auth: ReturnType<typeof getAuthContext>;
 	private _fx: ReturnType<typeof getExchangeRatesContext>;
 	private _transactions: TransactionsResponse[] = $state([]);
-	private sequence = new RequestSequence();
-	private debouncer = new Debouncer(DEBOUNCE_MS);
+	private sync: StaleSync;
 	private _unsubscribe: (() => void) | null = null;
 	private _disposed = false;
 	private _activeUserId = '';
@@ -55,13 +52,15 @@ class AccountCashflowContext {
 		AccountSharesPerspectiveOptions.NORMAL
 	);
 	private _teardownCallback = () => this.unsubscribeRealtime();
-	private _reconnectCallback = () => this.invalidate();
 
 	constructor(pb: PocketBaseContext) {
 		this._pb = pb;
 		this._auth = getAuthContext();
 		this._auth.registerRealtimeTeardown(this._teardownCallback);
-		this._pb.registerRealtimeReconnect(this._reconnectCallback);
+		this.sync = new StaleSync(pb, 'accountCashflow', 'refresh', (token) =>
+			this.recomputeAll(token)
+		);
+		this._pb.registerRealtimeSync(this.sync);
 		this._fx = getExchangeRatesContext();
 		this.init();
 	}
@@ -71,18 +70,16 @@ class AccountCashflowContext {
 			const userId = this._auth.currentUserId;
 			if (userId === this._activeUserId) return;
 			this.unsubscribeRealtime();
+			this.reset();
 			this._activeUserId = userId;
 			if (!userId) {
-				this.reset();
 				this.isLoading = false;
 				return;
 			}
 			this.realtimeSubscribe(userId);
 			if (this._accountId) {
 				this.isLoading = true;
-				void this.recomputeAll().catch((error) => {
-					this._pb.handleConnectionError(error, 'accountCashflow', 'init');
-				});
+				void this.sync.refreshNow();
 			}
 		});
 	}
@@ -103,9 +100,7 @@ class AccountCashflowContext {
 			return;
 		}
 		this.isLoading = true;
-		void this.recomputeAll().catch((error) => {
-			this._pb.handleConnectionError(error, 'accountCashflow', 'set_account');
-		});
+		void this.sync.refreshNow();
 	}
 
 	private realtimeSubscribe(userId = this._activeUserId) {
@@ -139,28 +134,20 @@ class AccountCashflowContext {
 		this._unsubscribe = null;
 	}
 
+	// A transaction event is a pure invalidation signal: it marks the store stale and schedules the
+	// windowed refetch rather than patching the event payload. Events for other accounts are filtered
+	// out here because this store caches exactly one account's transactions.
 	private onTransactionEvent(e: RecordSubscription<TransactionsResponse>) {
 		if (!e.action) return;
 		if (e.record.account !== this._accountId) return;
-		this.invalidate();
+		this.sync.invalidate();
 	}
 
-	// A transaction event or a realtime reconnect is a pure invalidation signal: it schedules the
-	// debounced windowed refetch rather than patching the event payload. A reconnect carries no
-	// record, so it recomputes only when an account is active and someone is signed in.
-	private invalidate() {
-		if (!this._activeUserId || !this._accountId) return;
-		this.debouncer.schedule(
-			() =>
-				void this.recomputeAll().catch((error) =>
-					this._pb.handleConnectionError(error, 'accountCashflow', 'refresh')
-				)
-		);
-	}
-
-	private async recomputeAll() {
+	private async recomputeAll(token: number) {
 		const accountId = this._accountId;
-		const token = this.sequence.next();
+		// Staleness is scoped to the mounted account, so a mark that arrives while none is mounted is
+		// a successful no-op: setAccount always refetches, and until it runs there is nothing to sync.
+		if (!accountId || !this._activeUserId) return;
 		const window = computeCashflowWindow();
 
 		try {
@@ -172,26 +159,24 @@ class AccountCashflowContext {
 					requestKey: null
 				});
 
-			if (!this.sequence.isCurrent(token)) return;
+			if (!this.sync.isCurrent(token)) return;
 
 			this._transactions = transactions;
 		} finally {
-			if (!this._disposed && this.sequence.isCurrent(token)) this.isLoading = false;
+			if (!this._disposed && this.sync.isCurrent(token)) this.isLoading = false;
 		}
 	}
 
 	private reset() {
-		this.sequence.bump();
-		this.debouncer.cancel();
+		this.sync.cancel();
 		this._transactions = [];
 	}
 
 	dispose() {
 		this._disposed = true;
-		this.sequence.bump();
-		this.debouncer.cancel();
+		this.sync.cancel();
 		this._auth.unregisterRealtimeTeardown(this._teardownCallback);
-		this._pb.unregisterRealtimeReconnect(this._reconnectCallback);
+		this._pb.unregisterRealtimeSync(this.sync);
 		this.unsubscribeRealtime();
 	}
 }

--- a/src/lib/accounts.svelte.ts
+++ b/src/lib/accounts.svelte.ts
@@ -13,7 +13,7 @@ import {
 	type AccountsResponse
 } from './pocketbase.schema';
 import type { PocketBaseContext } from './pocketbase.svelte';
-import { Debouncer, RequestSequence } from './realtime-sync';
+import { StaleSync } from './realtime-sync';
 import type { AccountPositionsValue } from './securities.svelte';
 import { sumOrUnknown } from './security-balance-values';
 import { participantExcluded, projectSignedValue } from './sharing';
@@ -49,8 +49,6 @@ type LatestCash = {
 	asOf: string;
 };
 
-const DEBOUNCE_MS = 200;
-
 class AccountsContext {
 	accounts: AccountWithBalance[] = $derived.by(() =>
 		this.rawAccounts.map((record) => {
@@ -80,12 +78,10 @@ class AccountsContext {
 	private _auth: ReturnType<typeof getAuthContext>;
 	private _fx: ReturnType<typeof getExchangeRatesContext>;
 	private balanceTypesContext: ReturnType<typeof setBalanceTypesContext>;
-	private sequence = new RequestSequence();
-	private debouncer = new Debouncer(DEBOUNCE_MS);
+	private sync: StaleSync;
 	private _activeUserId = '';
 	private _isSubscribed = false;
 	private _teardownCallback = () => this.unsubscribeRealtime();
-	private _reconnectCallback = () => this.invalidate();
 
 	constructor(
 		pb: PocketBaseContext,
@@ -94,7 +90,8 @@ class AccountsContext {
 		this._pb = pb;
 		this._auth = getAuthContext();
 		this._auth.registerRealtimeTeardown(this._teardownCallback);
-		this._pb.registerRealtimeReconnect(this._reconnectCallback);
+		this.sync = new StaleSync(pb, 'accounts', 'refresh', (token) => this.refreshAll(token));
+		this._pb.registerRealtimeSync(this.sync);
 		this._fx = getExchangeRatesContext();
 		this.balanceTypesContext = balanceTypesContext;
 		this.init();
@@ -152,17 +149,17 @@ class AccountsContext {
 			recipientEmail,
 			perspective
 		});
-		await this.refreshForCurrentUser();
+		await this.sync.refreshNow();
 	}
 
 	async updateShareIncludeInNetWorth(shareId: string, includeInNetWorth: boolean) {
 		await this._pb.authedClient.collection('accountShares').update(shareId, { includeInNetWorth });
-		await this.refreshForCurrentUser();
+		await this.sync.refreshNow();
 	}
 
 	async revokeShare(shareId: string) {
 		await this._pb.authedClient.collection('accountShares').delete(shareId);
-		await this.refreshForCurrentUser();
+		await this.sync.refreshNow();
 	}
 
 	private init() {
@@ -170,8 +167,7 @@ class AccountsContext {
 			const userId = this.currentUserId;
 			if (userId === this._activeUserId) return;
 			this.unsubscribeRealtime();
-			this.debouncer.cancel();
-			this.sequence.bump();
+			this.sync.cancel();
 			this._activeUserId = userId;
 			if (!userId) {
 				this.rawAccounts = [];
@@ -186,20 +182,22 @@ class AccountsContext {
 			this.accountsLoaded = false;
 			this.lastBalanceEvent = 0;
 			this.realtimeSubscribe(userId);
-			void this.refreshForCurrentUser();
+			void this.sync.refreshNow();
 		});
 	}
 
-	// Realtime events and reconnects are pure invalidation signals: they never patch a payload into
-	// state, they only schedule a full refetch. Deletes, share membership changes, and cross-account
-	// balance reassignments all resolve for free because the fresh snapshot reflects the database as-is.
-	private invalidate() {
-		this.debouncer.schedule(() => void this.refreshForCurrentUser());
+	// Refresh outside the debounce, for a caller that just wrote to the backend and needs its own
+	// change reflected immediately.
+	async refreshForCurrentUser() {
+		await this.sync.refreshNow();
 	}
 
-	async refreshForCurrentUser() {
+	// Realtime events and reconnects are pure invalidation signals: they never patch a payload into
+	// state, they only mark the store stale and schedule a full refetch. Deletes, share membership
+	// changes, and cross-account balance reassignments all resolve for free because the fresh
+	// snapshot reflects the database as-is.
+	private async refreshAll(token: number) {
 		const userId = this.currentUserId;
-		const token = this.sequence.next();
 		try {
 			const [shares, accounts, balances] = await Promise.all([
 				this._pb.authedClient.collection('accountShares').getFullList<AccountSharesResponse>({
@@ -220,11 +218,11 @@ class AccountsContext {
 					requestKey: null
 				})
 			]);
-			if (userId !== this.currentUserId || !this.sequence.isCurrent(token)) return;
+			if (userId !== this.currentUserId || !this.sync.isCurrent(token)) return;
 			for (const account of accounts) {
 				await this.balanceTypesContext.ensureLoaded(account.balanceType);
 			}
-			if (userId !== this.currentUserId || !this.sequence.isCurrent(token)) return;
+			if (userId !== this.currentUserId || !this.sync.isCurrent(token)) return;
 
 			this.shares = shares.toSorted((a, b) => a.recipientEmail.localeCompare(b.recipientEmail));
 			this.latestCashByAccount.clear();
@@ -238,11 +236,8 @@ class AccountsContext {
 			this.rawAccounts = accounts;
 			this.accountsLoaded = true;
 			this.notifyBalancesChanged();
-		} catch (error) {
-			if (userId !== this.currentUserId || !this.sequence.isCurrent(token)) return;
-			this._pb.handleConnectionError(error, 'accounts', 'refresh');
 		} finally {
-			if (userId === this.currentUserId && this.sequence.isCurrent(token)) this.isLoading = false;
+			if (userId === this.currentUserId && this.sync.isCurrent(token)) this.isLoading = false;
 		}
 	}
 
@@ -284,7 +279,7 @@ class AccountsContext {
 
 	private onRealtimeEvent(userId: string) {
 		if (!userId || userId !== this._activeUserId) return;
-		this.invalidate();
+		this.sync.invalidate();
 	}
 
 	private unsubscribeRealtime() {
@@ -351,11 +346,10 @@ class AccountsContext {
 	}
 
 	dispose() {
-		this.debouncer.cancel();
+		this.sync.cancel();
 		this._auth.unregisterRealtimeTeardown(this._teardownCallback);
-		this._pb.unregisterRealtimeReconnect(this._reconnectCallback);
+		this._pb.unregisterRealtimeSync(this.sync);
 		this.unsubscribeRealtime();
-		this.sequence.bump();
 	}
 }
 

--- a/src/lib/assets.svelte.ts
+++ b/src/lib/assets.svelte.ts
@@ -13,7 +13,7 @@ import {
 	type AssetsResponse
 } from './pocketbase.schema';
 import type { PocketBaseContext } from './pocketbase.svelte';
-import { Debouncer, RequestSequence } from './realtime-sync';
+import { StaleSync } from './realtime-sync';
 import { participantExcluded, projectAssetFinancials } from './sharing';
 import { toPocketBaseDateString } from './utils';
 
@@ -53,8 +53,6 @@ const DEFAULT_BALANCE_DATA: LatestAssetBalance = {
 	balanceAsOf: ''
 };
 
-const DEBOUNCE_MS = 200;
-
 export type AssetWithBalance = AssetsResponse &
 	AssetDisplayBalanceData & {
 		isOwner: boolean;
@@ -85,12 +83,10 @@ class AssetsContext {
 	private _auth: ReturnType<typeof getAuthContext>;
 	private _fx: ReturnType<typeof getExchangeRatesContext>;
 	private balanceTypesContext: ReturnType<typeof setBalanceTypesContext>;
-	private sequence = new RequestSequence();
-	private debouncer = new Debouncer(DEBOUNCE_MS);
+	private sync: StaleSync;
 	private _activeUserId = '';
 	private _isSubscribed = false;
 	private _teardownCallback = () => this.unsubscribeRealtime();
-	private _reconnectCallback = () => this.invalidate();
 
 	constructor(
 		pb: PocketBaseContext,
@@ -99,7 +95,8 @@ class AssetsContext {
 		this._pb = pb;
 		this._auth = getAuthContext();
 		this._auth.registerRealtimeTeardown(this._teardownCallback);
-		this._pb.registerRealtimeReconnect(this._reconnectCallback);
+		this.sync = new StaleSync(pb, 'assets', 'refresh', (token) => this.refreshAll(token));
+		this._pb.registerRealtimeSync(this.sync);
 		this._fx = getExchangeRatesContext();
 		this.balanceTypesContext = balanceTypesContext;
 		this.init();
@@ -143,17 +140,17 @@ class AssetsContext {
 			recipientEmail,
 			perspective
 		});
-		await this.refreshForCurrentUser();
+		await this.sync.refreshNow();
 	}
 
 	async updateShareIncludeInNetWorth(shareId: string, includeInNetWorth: boolean) {
 		await this._pb.authedClient.collection('assetShares').update(shareId, { includeInNetWorth });
-		await this.refreshForCurrentUser();
+		await this.sync.refreshNow();
 	}
 
 	async revokeShare(shareId: string) {
 		await this._pb.authedClient.collection('assetShares').delete(shareId);
-		await this.refreshForCurrentUser();
+		await this.sync.refreshNow();
 	}
 
 	private init() {
@@ -161,8 +158,7 @@ class AssetsContext {
 			const userId = this.currentUserId;
 			if (userId === this._activeUserId) return;
 			this.unsubscribeRealtime();
-			this.debouncer.cancel();
-			this.sequence.bump();
+			this.sync.cancel();
 			this._activeUserId = userId;
 			if (!userId) {
 				this.rawAssets = [];
@@ -175,20 +171,16 @@ class AssetsContext {
 			this.isLoading = true;
 			this.lastBalanceEvent = 0;
 			this.realtimeSubscribe(userId);
-			void this.refreshForCurrentUser();
+			void this.sync.refreshNow();
 		});
 	}
 
 	// Realtime events and reconnects are pure invalidation signals: they never patch a payload into
-	// state, they only schedule a full refetch. Deletes, share membership changes, and cross-asset
-	// balance reassignments all resolve for free because the fresh snapshot reflects the database as-is.
-	private invalidate() {
-		this.debouncer.schedule(() => void this.refreshForCurrentUser());
-	}
-
-	async refreshForCurrentUser() {
+	// state, they only mark the store stale and schedule a full refetch. Deletes, share membership
+	// changes, and cross-asset balance reassignments all resolve for free because the fresh snapshot
+	// reflects the database as-is.
+	private async refreshAll(token: number) {
 		const userId = this.currentUserId;
-		const token = this.sequence.next();
 		try {
 			const [shares, assets, balances] = await Promise.all([
 				this._pb.authedClient.collection('assetShares').getFullList<AssetSharesResponse>({
@@ -209,11 +201,11 @@ class AssetsContext {
 					requestKey: null
 				})
 			]);
-			if (userId !== this.currentUserId || !this.sequence.isCurrent(token)) return;
+			if (userId !== this.currentUserId || !this.sync.isCurrent(token)) return;
 			for (const asset of assets) {
 				await this.balanceTypesContext.ensureLoaded(asset.balanceType);
 			}
-			if (userId !== this.currentUserId || !this.sequence.isCurrent(token)) return;
+			if (userId !== this.currentUserId || !this.sync.isCurrent(token)) return;
 
 			this.shares = shares.toSorted((a, b) => a.recipientEmail.localeCompare(b.recipientEmail));
 			this.latestBalanceByAsset.clear();
@@ -227,11 +219,8 @@ class AssetsContext {
 			}
 			this.rawAssets = assets;
 			this.lastBalanceEvent = Date.now();
-		} catch (error) {
-			if (userId !== this.currentUserId || !this.sequence.isCurrent(token)) return;
-			this._pb.handleConnectionError(error, 'assets', 'refresh');
 		} finally {
-			if (userId === this.currentUserId && this.sequence.isCurrent(token)) this.isLoading = false;
+			if (userId === this.currentUserId && this.sync.isCurrent(token)) this.isLoading = false;
 		}
 	}
 
@@ -273,7 +262,7 @@ class AssetsContext {
 
 	private onRealtimeEvent(userId: string) {
 		if (!userId || userId !== this._activeUserId) return;
-		this.invalidate();
+		this.sync.invalidate();
 	}
 
 	private unsubscribeRealtime() {
@@ -355,11 +344,10 @@ class AssetsContext {
 	}
 
 	dispose() {
-		this.debouncer.cancel();
+		this.sync.cancel();
 		this._auth.unregisterRealtimeTeardown(this._teardownCallback);
-		this._pb.unregisterRealtimeReconnect(this._reconnectCallback);
+		this._pb.unregisterRealtimeSync(this.sync);
 		this.unsubscribeRealtime();
-		this.sequence.bump();
 	}
 }
 

--- a/src/lib/balance-types.svelte.ts
+++ b/src/lib/balance-types.svelte.ts
@@ -4,27 +4,24 @@ import { getAuthContext } from './auth.svelte';
 import { logError } from './logger';
 import type { BalanceTypesResponse } from './pocketbase.schema';
 import type { PocketBaseContext } from './pocketbase.svelte';
-import { Debouncer, RequestSequence } from './realtime-sync';
-
-const DEBOUNCE_MS = 200;
+import { StaleSync } from './realtime-sync';
 
 class BalanceTypesContext {
 	byId: Record<string, BalanceTypesResponse> = $state({});
 
 	private _pb: PocketBaseContext;
 	private _auth: ReturnType<typeof getAuthContext>;
-	private sequence = new RequestSequence();
-	private debouncer = new Debouncer(DEBOUNCE_MS);
+	private sync: StaleSync;
 	private _activeUserId = '';
 	private _isSubscribed = false;
 	private _teardownCallback = () => this.unsubscribeRealtime();
-	private _reconnectCallback = () => this.invalidate();
 
 	constructor(pb: PocketBaseContext) {
 		this._pb = pb;
 		this._auth = getAuthContext();
 		this._auth.registerRealtimeTeardown(this._teardownCallback);
-		this._pb.registerRealtimeReconnect(this._reconnectCallback);
+		this.sync = new StaleSync(pb, 'balance_types', 'refresh', (token) => this.refreshAll(token));
+		this._pb.registerRealtimeSync(this.sync);
 		this.init();
 	}
 
@@ -37,39 +34,28 @@ class BalanceTypesContext {
 			const userId = this.currentUserId;
 			if (userId === this._activeUserId) return;
 			this.unsubscribeRealtime();
-			this.debouncer.cancel();
-			this.sequence.bump();
+			this.sync.cancel();
 			this._activeUserId = userId;
 			if (!userId) {
 				this.byId = {};
 				return;
 			}
 			this.realtimeSubscribe(userId);
-			void this.refreshForCurrentUser();
+			void this.sync.refreshNow();
 		});
 	}
 
-	// Realtime events and reconnects are pure invalidation signals: they schedule a debounced full
-	// refetch of the dictionary rather than patching a single record from the event payload.
-	private invalidate() {
-		this.debouncer.schedule(() => void this.refreshForCurrentUser());
-	}
-
-	private async refreshForCurrentUser() {
+	// Realtime events and reconnects are pure invalidation signals: they mark the store stale and
+	// schedule a full refetch of the dictionary rather than patching a single record from the payload.
+	private async refreshAll(token: number) {
 		const userId = this.currentUserId;
-		const token = this.sequence.next();
-		try {
-			const list = await this._pb.authedClient
-				.collection('balanceTypes')
-				.getFullList<BalanceTypesResponse>({ requestKey: null });
-			if (userId !== this.currentUserId || !this.sequence.isCurrent(token)) return;
-			const map: Record<string, BalanceTypesResponse> = {};
-			for (const bt of list) map[bt.id] = bt;
-			this.byId = map;
-		} catch (error) {
-			if (userId !== this.currentUserId || !this.sequence.isCurrent(token)) return;
-			this._pb.handleConnectionError(error, 'balance_types', 'refresh');
-		}
+		const list = await this._pb.authedClient
+			.collection('balanceTypes')
+			.getFullList<BalanceTypesResponse>({ requestKey: null });
+		if (userId !== this.currentUserId || !this.sync.isCurrent(token)) return;
+		const map: Record<string, BalanceTypesResponse> = {};
+		for (const bt of list) map[bt.id] = bt;
+		this.byId = map;
 	}
 
 	private realtimeSubscribe(userId = this._activeUserId) {
@@ -89,7 +75,7 @@ class BalanceTypesContext {
 
 	private onRealtimeEvent(userId: string) {
 		if (!userId || userId !== this._activeUserId) return;
-		this.invalidate();
+		this.sync.invalidate();
 	}
 
 	private unsubscribeRealtime() {
@@ -103,16 +89,15 @@ class BalanceTypesContext {
 		return this.byId[id]?.name ?? '(Unknown)';
 	}
 
+	// Awaited inside the accounts and assets refresh loops, so a failure here must propagate: a
+	// swallowed one would let those stores commit a snapshot whose type names all read "(Unknown)"
+	// and clear their stale flag on it.
 	async ensureLoaded(id: string) {
 		if (!id || this.byId[id]) return;
-		try {
-			const bt = await this._pb.authedClient
-				.collection('balanceTypes')
-				.getOne<BalanceTypesResponse>(id);
-			this.byId = { ...this.byId, [bt.id]: bt };
-		} catch (error) {
-			logError('balanceTypes', 'ensure_loaded', error);
-		}
+		const bt = await this._pb.authedClient
+			.collection('balanceTypes')
+			.getOne<BalanceTypesResponse>(id, { requestKey: null });
+		this.byId = { ...this.byId, [bt.id]: bt };
 	}
 
 	async getOrCreate(name: string, ownerId: string): Promise<string> {
@@ -131,11 +116,10 @@ class BalanceTypesContext {
 	}
 
 	dispose() {
-		this.debouncer.cancel();
+		this.sync.cancel();
 		this._auth.unregisterRealtimeTeardown(this._teardownCallback);
-		this._pb.unregisterRealtimeReconnect(this._reconnectCallback);
+		this._pb.unregisterRealtimeSync(this.sync);
 		this.unsubscribeRealtime();
-		this.sequence.bump();
 	}
 }
 

--- a/src/lib/cashflow.svelte.ts
+++ b/src/lib/cashflow.svelte.ts
@@ -14,9 +14,7 @@ import { getExchangeRatesContext } from './exchange-rates.svelte';
 import { logError } from './logger';
 import { AccountSharesPerspectiveOptions, type TransactionsResponse } from './pocketbase.schema';
 import type { PocketBaseContext } from './pocketbase.svelte';
-import { Debouncer, RequestSequence } from './realtime-sync';
-
-const DEBOUNCE_MS = 200;
+import { StaleSync } from './realtime-sync';
 
 class CashflowContext {
 	avg3m: CashflowAverages = $state({
@@ -51,25 +49,24 @@ class CashflowContext {
 	private _auth: ReturnType<typeof getAuthContext>;
 	private _fx: ReturnType<typeof getExchangeRatesContext>;
 	private _accountsContext: ReturnType<typeof getAccountsContext>;
-	private debouncer = new Debouncer(DEBOUNCE_MS);
+	private sync: StaleSync;
 	private _unsubscribe: (() => void) | null = null;
 	private _disposed = false;
 	private _activeUserId = '';
 	private _isSubscribed = false;
-	private sequence = new RequestSequence();
 	private _recomputeAllInFlight = 0;
 	private _transactionsById = new SvelteMap<string, TransactionsResponse>();
 	private _activeWindow: CashflowWindow | null = null;
 	private _hasTransactionSnapshot = false;
 	private _watchedAccountsKey: string | null = null;
 	private _teardownCallback = () => this.unsubscribeRealtime();
-	private _reconnectCallback = () => this.invalidate();
 
 	constructor(pb: PocketBaseContext) {
 		this._pb = pb;
 		this._auth = getAuthContext();
 		this._auth.registerRealtimeTeardown(this._teardownCallback);
-		this._pb.registerRealtimeReconnect(this._reconnectCallback);
+		this.sync = new StaleSync(pb, 'cashflow', 'refresh', (token) => this.recomputeAll(token));
+		this._pb.registerRealtimeSync(this.sync);
 		this._fx = getExchangeRatesContext();
 		this._accountsContext = getAccountsContext();
 		this.init();
@@ -80,8 +77,7 @@ class CashflowContext {
 			const userId = this._auth.currentUserId;
 			if (userId === this._activeUserId) return;
 			this.unsubscribeRealtime();
-			this.debouncer.cancel();
-			this.sequence.bump();
+			this.sync.cancel();
 			this._activeUserId = userId;
 			if (!userId) {
 				this._transactionsById = new SvelteMap();
@@ -153,11 +149,10 @@ class CashflowContext {
 				}
 			}
 
+			// The key is recorded before the fetch so a balance-only tick can't re-trigger it; if the
+			// fetch fails the sync keeps the store stale and owns the retry, so the key stays put.
 			this._watchedAccountsKey = watchedAccountsKey;
-			void this.recomputeAll(accounts).catch((error) => {
-				if (this._watchedAccountsKey === watchedAccountsKey) this._watchedAccountsKey = null;
-				this._pb.handleConnectionError(error, 'cashflow', 'init');
-			});
+			void this.sync.refreshNow();
 		});
 	}
 
@@ -201,24 +196,15 @@ class CashflowContext {
 
 	private onRealtimeEvent(userId: string) {
 		if (!userId || userId !== this._activeUserId) return;
-		this.invalidate();
+		this.sync.invalidate();
 	}
 
 	// A transaction event (or a reconnect) is a pure invalidation signal: instead of patching the
-	// in-memory transaction map from the event payload, it schedules a debounced full refetch of the
-	// windowed transactions via recomputeAll. Projection (recomputeFromTransactionMap driven by the
+	// in-memory transaction map from the event payload, it marks the store stale and schedules a full
+	// refetch of the windowed transactions. Projection (recomputeFromTransactionMap driven by the
 	// accounts effect) stays incremental and network-free; only this sync path was ever a refetch.
-	private invalidate() {
-		this.debouncer.schedule(
-			() =>
-				void this.recomputeAll(this._accountsContext.accounts).catch((error) =>
-					this._pb.handleConnectionError(error, 'cashflow', 'refresh')
-				)
-		);
-	}
-
-	private async recomputeAll(accounts: AccountWithBalance[]) {
-		const token = this.sequence.next();
+	private async recomputeAll(token: number) {
+		const accounts = this._accountsContext.accounts;
 		const cashflowWindow = this.getCashflowWindow();
 
 		this._recomputeAllInFlight++;
@@ -231,7 +217,7 @@ class CashflowContext {
 					requestKey: null
 				});
 
-			if (!this.sequence.isCurrent(token)) return;
+			if (!this.sync.isCurrent(token)) return;
 
 			this._transactionsById = new SvelteMap(
 				txns.map((transaction) => [transaction.id, transaction])
@@ -242,7 +228,7 @@ class CashflowContext {
 			this.recomputeFromTransactionMap(accounts, cashflowWindow);
 		} finally {
 			this._recomputeAllInFlight--;
-			if (!this._disposed && this.sequence.isCurrent(token)) this.isLoading = false;
+			if (!this._disposed && this.sync.isCurrent(token)) this.isLoading = false;
 		}
 	}
 
@@ -281,10 +267,9 @@ class CashflowContext {
 
 	dispose() {
 		this._disposed = true;
-		this.sequence.bump();
-		this.debouncer.cancel();
+		this.sync.cancel();
 		this._auth.unregisterRealtimeTeardown(this._teardownCallback);
-		this._pb.unregisterRealtimeReconnect(this._reconnectCallback);
+		this._pb.unregisterRealtimeSync(this.sync);
 		this.unsubscribeRealtime();
 	}
 }

--- a/src/lib/currencies.svelte.ts
+++ b/src/lib/currencies.svelte.ts
@@ -5,9 +5,7 @@ import { getAuthContext } from './auth.svelte';
 import { logError } from './logger';
 import type { CurrenciesResponse } from './pocketbase.schema';
 import type { PocketBaseContext } from './pocketbase.svelte';
-import { Debouncer, RequestSequence } from './realtime-sync';
-
-const DEBOUNCE_MS = 200;
+import { StaleSync } from './realtime-sync';
 
 type CurrencyRegistryRow = {
 	id: string;
@@ -35,19 +33,17 @@ class CurrenciesContext {
 
 	private _pb: PocketBaseContext;
 	private _auth: ReturnType<typeof getAuthContext>;
-	private sequence = new RequestSequence();
-	private debouncer = new Debouncer(DEBOUNCE_MS);
+	private sync: StaleSync;
 	private _activeUserId = '';
 	private _isSubscribed = false;
-	private _disposed = false;
 	private _teardownCallback = () => this.unsubscribeRealtime();
-	private _reconnectCallback = () => this.invalidate();
 
 	constructor(pb: PocketBaseContext) {
 		this._pb = pb;
 		this._auth = getAuthContext();
 		this._auth.registerRealtimeTeardown(this._teardownCallback);
-		this._pb.registerRealtimeReconnect(this._reconnectCallback);
+		this.sync = new StaleSync(pb, 'currencies', 'refresh', (token) => this.refreshAll(token));
+		this._pb.registerRealtimeSync(this.sync);
 		this.init();
 	}
 
@@ -56,8 +52,7 @@ class CurrenciesContext {
 			const userId = this._auth.currentUserId;
 			if (userId === this._activeUserId) return;
 			this.unsubscribeRealtime();
-			this.debouncer.cancel();
-			this.sequence.bump();
+			this.sync.cancel();
 			this._activeUserId = userId;
 			if (!userId) {
 				this._records = [];
@@ -66,29 +61,24 @@ class CurrenciesContext {
 			}
 			this._isLoaded = false;
 			this.realtimeSubscribe(userId);
-			void this.refresh(userId);
+			void this.sync.refreshNow();
 		});
 	}
 
-	private async refresh(userId: string) {
-		if (!userId) return;
-		const token = this.sequence.next();
-		try {
-			const list = await this._pb.authedClient
-				.collection('currencies')
-				.getFullList<CurrenciesResponse>({
-					sort: 'code',
-					requestKey: null
-				});
-			if (this._disposed || userId !== this._activeUserId || !this.sequence.isCurrent(token))
-				return;
+	// Realtime events and reconnects are pure invalidation signals: both mark the store stale and
+	// schedule this full refetch, so a reconnect converges on any events missed while disconnected.
+	private async refreshAll(token: number) {
+		const userId = this._activeUserId;
+		const list = await this._pb.authedClient
+			.collection('currencies')
+			.getFullList<CurrenciesResponse>({
+				sort: 'code',
+				requestKey: null
+			});
+		if (userId !== this._activeUserId || !this.sync.isCurrent(token)) return;
 
-			this._records = list;
-			this._isLoaded = true;
-		} catch (error) {
-			if (userId !== this._activeUserId) return;
-			this._pb.handleConnectionError(error, 'currencies', 'refresh');
-		}
+		this._records = list;
+		this._isLoaded = true;
 	}
 
 	private realtimeSubscribe(userId: string) {
@@ -96,7 +86,7 @@ class CurrenciesContext {
 		this._isSubscribed = true;
 		this._pb.authedClient
 			.collection('currencies')
-			.subscribe('*', () => this.invalidate())
+			.subscribe('*', () => this.sync.invalidate())
 			.catch((error) => {
 				if (userId === this._activeUserId) {
 					this._pb.handleSubscriptionError(error, 'currencies', 'subscribe');
@@ -110,13 +100,6 @@ class CurrenciesContext {
 		if (!this._isSubscribed) return;
 		this._isSubscribed = false;
 		this._pb.authedClient.collection('currencies').unsubscribe('*');
-	}
-
-	// Realtime events and reconnects are pure invalidation signals: both schedule a debounced full
-	// refetch, so a reconnect converges on any events missed while the socket was disconnected.
-	private invalidate() {
-		if (!this._activeUserId) return;
-		this.debouncer.schedule(() => void this.refresh(this._activeUserId));
 	}
 
 	get currencies() {
@@ -144,12 +127,10 @@ class CurrenciesContext {
 	}
 
 	dispose() {
-		this._disposed = true;
-		this.debouncer.cancel();
+		this.sync.cancel();
 		this._auth.unregisterRealtimeTeardown(this._teardownCallback);
-		this._pb.unregisterRealtimeReconnect(this._reconnectCallback);
+		this._pb.unregisterRealtimeSync(this.sync);
 		this.unsubscribeRealtime();
-		this.sequence.bump();
 	}
 }
 

--- a/src/lib/exchange-rates.svelte.ts
+++ b/src/lib/exchange-rates.svelte.ts
@@ -7,9 +7,7 @@ import { interfacePreferences } from './interface-preferences.svelte';
 import { logError } from './logger';
 import type { ExchangeRatesResponse } from './pocketbase.schema';
 import type { PocketBaseContext } from './pocketbase.svelte';
-import { Debouncer, RequestSequence } from './realtime-sync';
-
-const DEBOUNCE_MS = 200;
+import { StaleSync } from './realtime-sync';
 
 export type CurrencyConversion = {
 	value: number;
@@ -58,20 +56,18 @@ class ExchangeRatesContext {
 	private _pb: PocketBaseContext;
 	private _auth: ReturnType<typeof getAuthContext>;
 	private _currencies: ReturnType<typeof setCurrenciesContext>;
-	private sequence = new RequestSequence();
-	private debouncer = new Debouncer(DEBOUNCE_MS);
+	private sync: StaleSync;
 	private _activeUserId = '';
 	private _isSubscribed = false;
-	private _disposed = false;
 	private _teardownCallback = () => this.unsubscribeRealtime();
-	private _reconnectCallback = () => this.invalidate();
 
 	constructor(pb: PocketBaseContext, currencies: ReturnType<typeof setCurrenciesContext>) {
 		this._pb = pb;
 		this._auth = getAuthContext();
 		this._currencies = currencies;
 		this._auth.registerRealtimeTeardown(this._teardownCallback);
-		this._pb.registerRealtimeReconnect(this._reconnectCallback);
+		this.sync = new StaleSync(pb, 'exchange_rates', 'refresh', (token) => this.refreshAll(token));
+		this._pb.registerRealtimeSync(this.sync);
 		this.init();
 	}
 
@@ -80,8 +76,7 @@ class ExchangeRatesContext {
 			const userId = this._auth.currentUserId;
 			if (userId === this._activeUserId) return;
 			this.unsubscribeRealtime();
-			this.debouncer.cancel();
-			this.sequence.bump();
+			this.sync.cancel();
 			this._activeUserId = userId;
 			if (!userId) {
 				this._records = [];
@@ -90,26 +85,22 @@ class ExchangeRatesContext {
 			}
 			this._isLoaded = false;
 			this.realtimeSubscribe(userId);
-			void this.refresh(userId);
+			void this.sync.refreshNow();
 		});
 	}
 
-	private async refresh(userId: string) {
-		if (!userId) return;
-		const token = this.sequence.next();
-		try {
-			const list = await this._pb.authedClient
-				.collection('exchangeRates')
-				.getFullList<ExchangeRatesResponse>({ requestKey: null });
-			if (this._disposed || userId !== this._activeUserId || !this.sequence.isCurrent(token))
-				return;
+	// NOTE: the ensure-rates worker writes many rows per entity, so coalesce the burst into a single
+	// refetch rather than maintaining the sorted index incrementally on each event. Reconnects route
+	// here too, converging on any events missed while the socket was disconnected.
+	private async refreshAll(token: number) {
+		const userId = this._activeUserId;
+		const list = await this._pb.authedClient
+			.collection('exchangeRates')
+			.getFullList<ExchangeRatesResponse>({ requestKey: null });
+		if (userId !== this._activeUserId || !this.sync.isCurrent(token)) return;
 
-			this._records = list;
-			this._isLoaded = true;
-		} catch (error) {
-			if (userId !== this._activeUserId) return;
-			this._pb.handleConnectionError(error, 'exchange_rates', 'refresh');
-		}
+		this._records = list;
+		this._isLoaded = true;
 	}
 
 	private realtimeSubscribe(userId: string) {
@@ -117,7 +108,7 @@ class ExchangeRatesContext {
 		this._isSubscribed = true;
 		this._pb.authedClient
 			.collection('exchangeRates')
-			.subscribe('*', () => this.invalidate())
+			.subscribe('*', () => this.sync.invalidate())
 			.catch((error) => {
 				if (userId === this._activeUserId) {
 					this._pb.handleSubscriptionError(error, 'exchange_rates', 'subscribe');
@@ -131,14 +122,6 @@ class ExchangeRatesContext {
 		if (!this._isSubscribed) return;
 		this._isSubscribed = false;
 		this._pb.authedClient.collection('exchangeRates').unsubscribe('*');
-	}
-
-	// NOTE: the ensure-rates worker writes many rows per entity, so coalesce the burst into a
-	// single refetch rather than maintaining the sorted index incrementally on each event. Reconnects
-	// route here too, converging on any events missed while the socket was disconnected.
-	private invalidate() {
-		if (!this._activeUserId) return;
-		this.debouncer.schedule(() => void this.refresh(this._activeUserId));
 	}
 
 	get records() {
@@ -203,12 +186,10 @@ class ExchangeRatesContext {
 	}
 
 	dispose() {
-		this._disposed = true;
-		this.debouncer.cancel();
+		this.sync.cancel();
 		this._auth.unregisterRealtimeTeardown(this._teardownCallback);
-		this._pb.unregisterRealtimeReconnect(this._reconnectCallback);
+		this._pb.unregisterRealtimeSync(this.sync);
 		this.unsubscribeRealtime();
-		this.sequence.bump();
 	}
 }
 

--- a/src/lib/import-sessions.svelte.ts
+++ b/src/lib/import-sessions.svelte.ts
@@ -4,9 +4,7 @@ import { getAuthContext } from './auth.svelte';
 import { logError } from './logger';
 import type { ImportSessionsResponse } from './pocketbase.schema';
 import type { PocketBaseContext } from './pocketbase.svelte';
-import { Debouncer, RequestSequence } from './realtime-sync';
-
-const DEBOUNCE_MS = 200;
+import { StaleSync } from './realtime-sync';
 
 class ImportSessionsContext {
 	sessions: ImportSessionsResponse[] = $state([]);
@@ -14,18 +12,17 @@ class ImportSessionsContext {
 
 	private _pb: PocketBaseContext;
 	private _auth: ReturnType<typeof getAuthContext>;
-	private sequence = new RequestSequence();
-	private debouncer = new Debouncer(DEBOUNCE_MS);
+	private sync: StaleSync;
 	private _activeUserId = '';
 	private _isSubscribed = false;
 	private _teardownCallback = () => this.unsubscribeRealtime();
-	private _reconnectCallback = () => this.invalidate();
 
 	constructor(pb: PocketBaseContext) {
 		this._pb = pb;
 		this._auth = getAuthContext();
 		this._auth.registerRealtimeTeardown(this._teardownCallback);
-		this._pb.registerRealtimeReconnect(this._reconnectCallback);
+		this.sync = new StaleSync(pb, 'importSessions', 'refresh', (token) => this.refreshAll(token));
+		this._pb.registerRealtimeSync(this.sync);
 		this.init();
 	}
 
@@ -38,8 +35,7 @@ class ImportSessionsContext {
 			const userId = this.currentUserId;
 			if (userId === this._activeUserId) return;
 			this.unsubscribeRealtime();
-			this.debouncer.cancel();
-			this.sequence.bump();
+			this.sync.cancel();
 			this._activeUserId = userId;
 			if (!userId) {
 				this.sessions = [];
@@ -48,30 +44,23 @@ class ImportSessionsContext {
 			}
 			this.isLoading = true;
 			this.realtimeSubscribe(userId);
-			void this.refreshForCurrentUser();
+			void this.sync.refreshNow();
 		});
 	}
 
-	// Realtime events and reconnects are pure invalidation signals: they schedule a debounced full
-	// refetch sorted '-created', which reproduces the newest-first order without patching the payload.
-	private invalidate() {
-		this.debouncer.schedule(() => void this.refreshForCurrentUser());
-	}
-
-	private async refreshForCurrentUser() {
+	// Realtime events and reconnects are pure invalidation signals: they mark the store stale and
+	// schedule a full refetch sorted '-created', which reproduces the newest-first order without
+	// patching the payload.
+	private async refreshAll(token: number) {
 		const userId = this.currentUserId;
-		const token = this.sequence.next();
 		try {
 			const sessions = await this._pb.authedClient
 				.collection('importSessions')
 				.getFullList<ImportSessionsResponse>({ sort: '-created', requestKey: null });
-			if (userId !== this.currentUserId || !this.sequence.isCurrent(token)) return;
+			if (userId !== this.currentUserId || !this.sync.isCurrent(token)) return;
 			this.sessions = sessions;
-		} catch (error) {
-			if (userId !== this.currentUserId || !this.sequence.isCurrent(token)) return;
-			this._pb.handleConnectionError(error, 'importSessions', 'refresh');
 		} finally {
-			if (userId === this.currentUserId && this.sequence.isCurrent(token)) this.isLoading = false;
+			if (userId === this.currentUserId && this.sync.isCurrent(token)) this.isLoading = false;
 		}
 	}
 
@@ -93,7 +82,7 @@ class ImportSessionsContext {
 
 	private onRealtimeEvent(userId: string) {
 		if (!userId || userId !== this._activeUserId) return;
-		this.invalidate();
+		this.sync.invalidate();
 	}
 
 	private unsubscribeRealtime() {
@@ -103,11 +92,10 @@ class ImportSessionsContext {
 	}
 
 	dispose() {
-		this.debouncer.cancel();
+		this.sync.cancel();
 		this._auth.unregisterRealtimeTeardown(this._teardownCallback);
-		this._pb.unregisterRealtimeReconnect(this._reconnectCallback);
+		this._pb.unregisterRealtimeSync(this.sync);
 		this.unsubscribeRealtime();
-		this.sequence.bump();
 	}
 }
 

--- a/src/lib/pocketbase.svelte.ts
+++ b/src/lib/pocketbase.svelte.ts
@@ -7,14 +7,10 @@ import { browser } from '$app/environment';
 import { logError } from './logger';
 import { m } from './paraglide/messages';
 import type { TypedPocketBase } from './pocketbase.schema';
+import type { StaleSync } from './realtime-sync';
 import { getBackendUrl } from './utils';
 
 export type SetupStatus = 'checking' | 'ready' | 'needs-setup' | 'unreachable';
-
-// Waits between backend health probes during a recovery attempt. The list doubles as the attempt
-// budget: after the last delay the attempt gives up and waits for the next trigger, so a user who
-// stays offline for an hour is probed a handful of times, not continuously.
-const RECOVERY_PROBE_DELAYS_MS = [1000, 2000, 4000, 8000, 16000, 30000];
 
 enum ToastId {
 	CONNECTION_ERROR = 'connection-error',
@@ -28,17 +24,15 @@ export class PocketBaseContext {
 	onAuthInvalidated?: () => void;
 
 	// eslint-disable-next-line svelte/prefer-svelte-reactivity -- never read in a reactive context
-	private _reconnectCallbacks = new Set<() => void>();
-	private _reconnectListening = false;
-	private _pendingReconnect = false;
-	private _recovering = false;
-	private _pendingRecovery = false;
+	private _syncs = new Set<StaleSync>();
+	private _syncListening = false;
+	private _probe: Promise<boolean> | null = null;
 	// Fires on the two browser signals that a dead connection may be usable again: the network
 	// coming back, and the tab becoming visible after a sleep/wake or a backgrounded stretch. While
 	// hidden the tab is left alone - the visibility signal picks it up when the user returns.
-	private _recoveryTrigger = () => {
+	private _retryTrigger = () => {
 		if (document.visibilityState !== 'visible') return;
-		void this.recoverRealtime();
+		for (const sync of this._syncs) sync.retryNow();
 	};
 
 	constructor() {
@@ -47,81 +41,58 @@ export class PocketBaseContext {
 
 	// NOTE: the SDK resubmits subscriptions on realtime reconnect but never replays events emitted
 	// while disconnected, so records shared to the user during that gap (e.g. a laptop wake or
-	// network blip) stay invisible until a full re-init. Registered stores refetch on reconnect so a
-	// session converges with what the backend allows without a logout/login.
+	// network blip) stay invisible until a full re-init. The registry marks every store stale the
+	// moment the socket drops, and the store stays stale until a refresh actually commits - so a
+	// session converges without a logout/login even if the first few attempts fail.
 	//
 	// The SDK only reconnects when the EventSource reports a transport error, and EventSource has no
 	// liveness detection: an offline network or a slept laptop routinely leaves the socket in an OPEN
-	// state that never errors, so `onDisconnect` never fires and nothing would ever refetch. The
-	// browser's `online` and `visibilitychange` signals are therefore part of the recovery contract,
-	// not a nicety - they are the only trigger in the failing case.
-	registerRealtimeReconnect(callback: () => void) {
-		this._reconnectCallbacks.add(callback);
-		if (this._reconnectListening) return;
-		this._reconnectListening = true;
+	// state that never errors, so `onDisconnect` never fires and nothing would mark the stores stale.
+	// The browser's `online` and `visibilitychange` signals are therefore part of the recovery
+	// contract, not a nicety - they are the only trigger in the failing case.
+	registerRealtimeSync(sync: StaleSync) {
+		this._syncs.add(sync);
+		if (this._syncListening) return;
+		this._syncListening = true;
 		this.authedClient.realtime.onDisconnect = (activeSubscriptions) => {
-			this._pendingReconnect = activeSubscriptions.length > 0;
+			// Only a drop that had live subscriptions can have missed events; the SDK also reports this
+			// while negotiating the very first connection, which has nothing to miss yet.
+			if (activeSubscriptions.length === 0) return;
+			for (const sync of this._syncs) sync.markStale();
 		};
+		// PB_CONNECT is the most precise "the backend is reachable again" signal available, but it
+		// carries no correctness of its own: it only pokes stores that already know they missed
+		// something, and a store that is not stale ignores it.
 		void this.authedClient.realtime
 			.subscribe('PB_CONNECT', () => {
-				if (!this._pendingReconnect) return;
-				this._pendingReconnect = false;
-				void this.recoverRealtime();
+				for (const sync of this._syncs) sync.retryNow();
 			})
 			.catch((error) => logError('pocketbase', 'reconnect_subscribe', error));
 		if (!browser) return;
-		window.addEventListener('online', this._recoveryTrigger);
-		document.addEventListener('visibilitychange', this._recoveryTrigger);
+		window.addEventListener('online', this._retryTrigger);
+		document.addEventListener('visibilitychange', this._retryTrigger);
 	}
 
-	unregisterRealtimeReconnect(callback: () => void) {
-		this._reconnectCallbacks.delete(callback);
+	unregisterRealtimeSync(sync: StaleSync) {
+		this._syncs.delete(sync);
 	}
 
-	// A refetch issued the instant a trigger fires can still hit a network that is not usable yet (an
-	// `online` event precedes real connectivity, and a store refetch that fails is discarded), so
-	// recovery is latched: it probes the backend on a bounded backoff and only invalidates the stores
-	// once the backend actually answers. `_recovering` coalesces a burst of triggers - an SDK
-	// reconnect, `online`, and `visibilitychange` typically arrive together - into a single refetch.
-	// A trigger that lands while a round is already running is not dropped: the running round may
-	// have read state from before whatever prompted the new trigger (a PB_CONNECT can arrive while a
-	// visibility-triggered round is mid-flight), so it latches `_pendingRecovery` and a follow-up
-	// round runs when the current one settles - the same follow-up rule stores apply to events that
-	// arrive mid-fetch.
-	private async recoverRealtime() {
-		if (!this.authedClient.authStore.isValid) return;
-		if (this._recovering) {
-			this._pendingRecovery = true;
-			return;
-		}
-		this._recovering = true;
-		try {
-			for (let attempt = 0; ; attempt++) {
-				try {
-					await this.authedClient.health.check({ requestKey: null });
-					break;
-				} catch (error) {
-					if (attempt === RECOVERY_PROBE_DELAYS_MS.length) {
-						logError('pocketbase', 'recovery_unreachable', error);
-						return;
-					}
-					await new Promise((resolve) => setTimeout(resolve, RECOVERY_PROBE_DELAYS_MS[attempt]));
-				}
-			}
-			for (const reconnect of this._reconnectCallbacks) {
-				try {
-					reconnect();
-				} catch (error) {
-					logError('pocketbase', 'reconnect_callback', error);
-				}
-			}
-		} finally {
-			this._recovering = false;
-			if (this._pendingRecovery) {
-				this._pendingRecovery = false;
-				void this.recoverRealtime();
-			}
-		}
+	// Shared reachability gate for stale-store retries. An `online` event precedes real connectivity
+	// and a slept laptop's socket lies about being open, so a retry round asks this first: one small
+	// request answers for every store, instead of a dozen doomed refetches per tick. It is a gate the
+	// retries await, not a latch - marking a store stale is idempotent and the flag outlives any
+	// round, so a trigger landing mid-round is coalesced rather than dropped.
+	probeBackend() {
+		this._probe ??= this.authedClient.health
+			.check({ requestKey: null })
+			.then(
+				() => true,
+				() => false
+			)
+			.finally(() => {
+				this._probe = null;
+			});
+		return this._probe;
 	}
 
 	get backendUrl(): string {

--- a/src/lib/realtime-sync.ts
+++ b/src/lib/realtime-sync.ts
@@ -1,6 +1,8 @@
+import { browser } from '$app/environment';
+
 // Monotonic latest-request guard. An async refresh takes a token from next() and bails as soon as
 // isCurrent(token) turns false because a newer refresh - or a supersede via bump() - advanced it.
-export class RequestSequence {
+class RequestSequence {
 	private value = 0;
 
 	next() {
@@ -21,23 +23,139 @@ export class RequestSequence {
 	}
 }
 
-// Trailing-edge debounce. schedule() coalesces a burst of realtime events into a single deferred
-// call; cancel() drops any pending call on dispose or logout.
-export class Debouncer {
+// Trailing edge for a burst of realtime events, so a bulk import settles into one refetch.
+const DEBOUNCE_MS = 200;
+// First retry after a failed refresh, then doubling. Unbounded in attempts, capped in delay: a
+// session that stays offline for an hour costs one small probe every 30s and still converges the
+// moment the backend answers.
+const FIRST_RETRY_MS = 1000;
+const MAX_RETRY_MS = 30000;
+
+// The slice of PocketBaseContext a sync needs: a shared reachability probe and the deduped
+// connection-error toast. Structural so this module stays free of context imports.
+type SyncClient = {
+	probeBackend: () => Promise<boolean>;
+	handleConnectionError: (error: unknown, context: string, operation: string) => void;
+};
+
+// Durable per-store staleness. A store that missed an update stays marked stale until a refresh
+// actually commits, so a transient failure can never leave finance data quietly out of date.
+// Signals - realtime events, reconnects, `online`, `visibilitychange` - only mark a store stale and
+// poke its retry; none of them carries correctness on its own.
+export class StaleSync {
+	private sequence = new RequestSequence();
 	private timer: ReturnType<typeof setTimeout> | null = null;
+	private isStale = false;
+	// Counts every "you may have missed something" signal. A refresh only clears the flag if no new
+	// signal arrived while it was in flight - a refresh that was already running when the socket
+	// dropped read the server before the update it is supposed to catch up on.
+	private markCount = 0;
+	private retryDelayMs = FIRST_RETRY_MS;
 
-	constructor(private delayMs: number) {}
+	constructor(
+		private client: SyncClient,
+		private context: string,
+		private operation: string,
+		private refresh: (token: number) => Promise<void>
+	) {}
 
-	schedule(callback: () => void) {
-		if (this.timer) clearTimeout(this.timer);
-		this.timer = setTimeout(() => {
-			this.timer = null;
-			callback();
-		}, this.delayMs);
+	// The epoch a refresh the store runs on its own must check, so it is dropped once a user change
+	// or a dispose has bumped the sequence.
+	get current() {
+		return this.sequence.current;
 	}
 
+	isCurrent(token: number) {
+		return this.sequence.isCurrent(token);
+	}
+
+	// A realtime event: the store may have missed something, and the event itself is evidence the
+	// socket is alive, so the backoff restarts and the refetch runs ungated.
+	invalidate() {
+		this.markStale();
+		this.retryDelayMs = FIRST_RETRY_MS;
+		this.schedule(DEBOUNCE_MS, false);
+	}
+
+	// The socket dropped: everything the store holds is possibly stale. Marking is idempotent and the
+	// flag outlives any single recovery round, so a signal arriving mid-round can never be lost.
+	markStale() {
+		this.isStale = true;
+		this.markCount++;
+	}
+
+	// A "the backend may be reachable again" trigger. Only a store that knows it missed something
+	// does any work; the backoff restarts because the world just told us the network changed.
+	retryNow() {
+		if (!this.isStale) return;
+		this.retryDelayMs = FIRST_RETRY_MS;
+		this.schedule(DEBOUNCE_MS, true);
+	}
+
+	// Refresh straight away, dropping any pending run so the same refetch is not issued twice. Used
+	// for the initial load and for a user's own write, where waiting out the debounce would show
+	// stale data back to the person who just changed it.
+	async refreshNow() {
+		this.clearTimer();
+		await this.run(false);
+	}
+
+	// Drop everything in flight and forget the staleness: the store is about to reload from scratch
+	// for a different user, or is going away.
 	cancel() {
+		this.clearTimer();
+		this.sequence.bump();
+		this.isStale = false;
+		this.markCount = 0;
+		this.retryDelayMs = FIRST_RETRY_MS;
+	}
+
+	private schedule(delayMs: number, gated: boolean) {
+		this.clearTimer();
+		this.timer = setTimeout(() => {
+			this.timer = null;
+			void this.run(gated);
+		}, delayMs);
+	}
+
+	private clearTimer() {
 		if (this.timer) clearTimeout(this.timer);
 		this.timer = null;
+	}
+
+	private async run(gated: boolean) {
+		if (gated) {
+			// A hidden tab is deliberately left alone; the visibilitychange trigger picks its retry back
+			// up when the user returns, so a backgrounded session burns nothing.
+			if (browser && document.hidden) return;
+			// One shared health probe gates the whole retry round, so a tick while the backend is
+			// unreachable costs a single small request instead of a doomed refetch per store.
+			if (!(await this.client.probeBackend())) {
+				this.scheduleRetry();
+				return;
+			}
+		}
+
+		const marksAtStart = this.markCount;
+		const token = this.sequence.next();
+		try {
+			await this.refresh(token);
+			// A superseded run belongs to the newer run, which will clear or keep the flag itself.
+			// Re-marking here would resurrect staleness the newer run is about to resolve.
+			if (!this.sequence.isCurrent(token)) return;
+			if (this.markCount === marksAtStart) this.isStale = false;
+			this.retryDelayMs = FIRST_RETRY_MS;
+		} catch (error) {
+			if (!this.sequence.isCurrent(token)) return;
+			this.isStale = true;
+			this.client.handleConnectionError(error, this.context, this.operation);
+			this.scheduleRetry();
+		}
+	}
+
+	private scheduleRetry() {
+		const delayMs = this.retryDelayMs;
+		this.retryDelayMs = Math.min(this.retryDelayMs * 2, MAX_RETRY_MS);
+		this.schedule(delayMs, true);
 	}
 }

--- a/src/lib/securities.svelte.ts
+++ b/src/lib/securities.svelte.ts
@@ -7,7 +7,7 @@ import { getExchangeRatesContext } from './exchange-rates.svelte';
 import { logError } from './logger';
 import type { SecuritiesResponse, SecurityBalancesResponse } from './pocketbase.schema';
 import type { PocketBaseContext } from './pocketbase.svelte';
-import { Debouncer, RequestSequence } from './realtime-sync';
+import { StaleSync } from './realtime-sync';
 import {
 	compareByValueDescThenName,
 	resolveSecurityBalanceValues,
@@ -83,8 +83,6 @@ type PositionsAccumulator = {
 	missingCurrency: string | null;
 };
 
-const DEBOUNCE_MS = 200;
-
 class SecuritiesContext {
 	securities: SecuritiesResponse[] = $state([]);
 	isLoading = $state(true);
@@ -139,18 +137,17 @@ class SecuritiesContext {
 	private _auth: ReturnType<typeof getAuthContext>;
 	private _accounts: ReturnType<typeof getAccountsContext>;
 	private _fx: ReturnType<typeof getExchangeRatesContext>;
-	private sequence = new RequestSequence();
-	private debouncer = new Debouncer(DEBOUNCE_MS);
+	private sync: StaleSync;
 	private _activeUserId = '';
 	private _isSubscribed = false;
 	private _teardownCallback = () => this.unsubscribeRealtime();
-	private _reconnectCallback = () => this.invalidate();
 
 	constructor(pb: PocketBaseContext) {
 		this._pb = pb;
 		this._auth = getAuthContext();
 		this._auth.registerRealtimeTeardown(this._teardownCallback);
-		this._pb.registerRealtimeReconnect(this._reconnectCallback);
+		this.sync = new StaleSync(pb, 'securities', 'refresh', (token) => this.refreshAll(token));
+		this._pb.registerRealtimeSync(this.sync);
 		this._accounts = getAccountsContext();
 		this._fx = getExchangeRatesContext();
 		this.init();
@@ -182,7 +179,7 @@ class SecuritiesContext {
 		});
 		// Refresh directly rather than via the debounce so the user's own write shows immediately;
 		// refreshAll notifies accounts of the new balances on commit.
-		await this.refreshForCurrentUser();
+		await this.sync.refreshNow();
 	}
 
 	private init() {
@@ -190,8 +187,7 @@ class SecuritiesContext {
 			const userId = this._auth.currentUserId;
 			if (userId === this._activeUserId) return;
 			this.unsubscribeRealtime();
-			this.debouncer.cancel();
-			this.sequence.bump();
+			this.sync.cancel();
 			this._activeUserId = userId;
 			if (!userId) {
 				this.securities = [];
@@ -203,59 +199,46 @@ class SecuritiesContext {
 			this.isLoading = true;
 			this.positionsLoaded = false;
 			this.realtimeSubscribe(userId);
-			void this.refreshForCurrentUser();
+			void this.sync.refreshNow();
 		});
 	}
 
 	// Realtime events and reconnects are pure invalidation signals: they never patch a payload into
-	// state, they only schedule a full refetch. A security delete cascades to its securityBalances
-	// server-side, so the deleted rows are simply absent from the next snapshot - no epoch guard or
-	// buffered replay is needed to keep them gone.
-	private invalidate() {
-		this.debouncer.schedule(() => void this.refreshForCurrentUser());
-	}
-
-	private async refreshForCurrentUser() {
+	// state, they only mark the store stale and schedule a full refetch. A security delete cascades
+	// to its securityBalances server-side, so the deleted rows are simply absent from the next
+	// snapshot - no epoch guard or buffered replay is needed to keep them gone.
+	private async refreshAll(token: number) {
 		const userId = this._auth.currentUserId;
-		const token = this.sequence.next();
 		try {
-			await this.refreshAll(userId, token);
-		} catch (error) {
-			if (userId !== this._auth.currentUserId || !this.sequence.isCurrent(token)) return;
-			this._pb.handleConnectionError(error, 'securities', 'refresh');
-			this.resolvePositionsLoaded();
+			const [securities, securityBalances] = await Promise.all([
+				this._pb.authedClient.collection('securities').getFullList<SecuritiesResponse>({
+					sort: 'name',
+					requestKey: null
+				}),
+				this._pb.authedClient.collection('securityBalances').getFullList<SecurityBalance>({
+					sort: 'security,account,-asOf,-created,-id',
+					requestKey: null
+				})
+			]);
+			if (userId !== this._auth.currentUserId || !this.sync.isCurrent(token)) return;
+
+			this.securities = securities.toSorted((a, b) =>
+				a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
+			);
+			this.currentPositions.clear();
+			for (const [key, position] of resolveSecurityBalanceValues(securityBalances)) {
+				this.currentPositions.set(key, position);
+			}
 		} finally {
-			if (userId === this._auth.currentUserId && this.sequence.isCurrent(token))
+			// "We tried" is what unblocks the accounts projection, not "we succeeded": a failed refresh
+			// must not leave every account's balance waiting on positions forever. Whether the refresh
+			// actually caught up is tracked separately by the sync's stale flag, which keeps retrying.
+			if (userId === this._auth.currentUserId && this.sync.isCurrent(token)) {
+				this.positionsLoaded = true;
+				this._accounts.notifyBalancesChanged();
 				this.isLoading = false;
+			}
 		}
-	}
-
-	private resolvePositionsLoaded() {
-		this.positionsLoaded = true;
-		this._accounts.notifyBalancesChanged();
-	}
-
-	private async refreshAll(userId: string, token: number) {
-		const [securities, securityBalances] = await Promise.all([
-			this._pb.authedClient.collection('securities').getFullList<SecuritiesResponse>({
-				sort: 'name',
-				requestKey: null
-			}),
-			this._pb.authedClient.collection('securityBalances').getFullList<SecurityBalance>({
-				sort: 'security,account,-asOf,-created,-id',
-				requestKey: null
-			})
-		]);
-		if (userId !== this._auth.currentUserId || !this.sequence.isCurrent(token)) return;
-
-		this.securities = securities.toSorted((a, b) =>
-			a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
-		);
-		this.currentPositions.clear();
-		for (const [key, position] of resolveSecurityBalanceValues(securityBalances)) {
-			this.currentPositions.set(key, position);
-		}
-		this.resolvePositionsLoaded();
 	}
 
 	private realtimeSubscribe(userId = this._activeUserId) {
@@ -286,7 +269,7 @@ class SecuritiesContext {
 
 	private onRealtimeEvent(userId: string) {
 		if (!userId || userId !== this._activeUserId) return;
-		this.invalidate();
+		this.sync.invalidate();
 	}
 
 	private unsubscribeRealtime() {
@@ -409,11 +392,10 @@ class SecuritiesContext {
 	}
 
 	dispose() {
-		this.debouncer.cancel();
+		this.sync.cancel();
 		this._auth.unregisterRealtimeTeardown(this._teardownCallback);
-		this._pb.unregisterRealtimeReconnect(this._reconnectCallback);
+		this._pb.unregisterRealtimeSync(this.sync);
 		this.unsubscribeRealtime();
-		this.sequence.bump();
 	}
 }
 

--- a/src/lib/trades.svelte.ts
+++ b/src/lib/trades.svelte.ts
@@ -17,12 +17,13 @@ import {
 	type SecurityTransactionsResponse
 } from './pocketbase.schema';
 import type { PocketBaseContext } from './pocketbase.svelte';
-import { Debouncer } from './realtime-sync';
+import { StaleSync } from './realtime-sync';
 import { getSecuritiesContext } from './securities.svelte';
 import type { PeriodOption } from './transactions.svelte';
 import { toNumber, toPocketBaseDateString } from './utils';
 
-const REFRESH_DEBOUNCE_MS = 200;
+const TRADE_FIELDS =
+	'id,date,security,type,subtype,description,name,account,quantity,price,amount,fees,expand.account.id,expand.account.name,expand.security.id,expand.security.name,expand.security.symbol,expand.security.currency';
 
 type TradeExpand = {
 	account?: AccountsResponse;
@@ -54,12 +55,12 @@ class TradesContext {
 	private _customLabel: string | null = $state(null);
 	private _searchDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 	private _loadingDelayTimer: ReturnType<typeof setTimeout> | null = null;
-	private _refreshDebouncer = new Debouncer(REFRESH_DEBOUNCE_MS);
+	private sync: StaleSync;
 	private _activeUserId = '';
 	private _isSubscribed = false;
 	private _teardownCallback = () => this.unsubscribeRealtime();
-	private _reconnectCallback = () => this.invalidate();
-	private _refreshSequence = 0;
+	// Latest-wins guards for the two result slots a refresh commits into. They are separate because a
+	// page-only refetch must not discard an in-flight full refresh's summary commit.
 	private _pageRefreshSequence = 0;
 	private _summaryRefreshSequence = 0;
 
@@ -83,7 +84,10 @@ class TradesContext {
 		this._pb = pb;
 		this._auth = getAuthContext();
 		this._auth.registerRealtimeTeardown(this._teardownCallback);
-		this._pb.registerRealtimeReconnect(this._reconnectCallback);
+		this.sync = new StaleSync(pb, 'securityTransactions', 'refresh', (token) =>
+			this.refreshTransactions(token)
+		);
+		this._pb.registerRealtimeSync(this.sync);
 		this._accountsContext = getAccountsContext();
 		this._securitiesContext = getSecuritiesContext();
 		this.syncFromUrl(false);
@@ -150,7 +154,7 @@ class TradesContext {
 
 		if (shouldRefresh) {
 			this.page = 1;
-			this.refreshTransactions();
+			void this.sync.refreshNow();
 		}
 	}
 
@@ -172,7 +176,7 @@ class TradesContext {
 		}
 
 		this._searchDebounceTimer = setTimeout(() => {
-			this.refreshTransactions();
+			void this.sync.refreshNow();
 		}, TradesContext.SEARCH_DEBOUNCE_MS);
 	}
 
@@ -191,7 +195,7 @@ class TradesContext {
 
 		this.updateUrl(params);
 		this.page = 1;
-		this.refreshTransactions();
+		void this.sync.refreshNow();
 	}
 
 	setCustomRange(from: Date, to: Date) {
@@ -208,28 +212,28 @@ class TradesContext {
 
 		this.updateUrl(params);
 		this.page = 1;
-		this.refreshTransactions();
+		void this.sync.refreshNow();
 	}
 
 	setAccountFilter(accountId: string | null) {
 		this.accountFilter = accountId;
 		this.page = 1;
 		this.syncFiltersToUrl();
-		this.refreshTransactions();
+		void this.sync.refreshNow();
 	}
 
 	setSecurityFilter(securityId: string | null) {
 		this.securityFilter = securityId;
 		this.page = 1;
 		this.syncFiltersToUrl();
-		this.refreshTransactions();
+		void this.sync.refreshNow();
 	}
 
 	setTypeFilter(type: TradeTypeFilter) {
 		this.typeFilter = type;
 		this.page = 1;
 		this.syncFiltersToUrl();
-		this.refreshTransactions();
+		void this.sync.refreshNow();
 	}
 
 	private escapeFilterValue(value: string) {
@@ -268,8 +272,30 @@ class TradesContext {
 		return filterParts.length > 0 ? filterParts.join(' && ') : undefined;
 	}
 
-	async refreshTransactions(userId = this._activeUserId, includeSummary = true) {
-		if (userId && userId !== this._activeUserId) return;
+	// The spinner only appears if a refresh is still running after a beat, so a fast refetch doesn't
+	// flash it. The delayed flip is dropped once a newer refresh has taken over.
+	private startLoadingDelay(userId: string, token: number, pageRefreshId: number) {
+		this.clearLoadingDelay();
+		this._loadingDelayTimer = setTimeout(() => {
+			if (
+				userId !== this._activeUserId ||
+				!this.sync.isCurrent(token) ||
+				pageRefreshId !== this._pageRefreshSequence
+			)
+				return;
+			this.isLoading = true;
+		}, TradesContext.LOADING_DELAY_MS);
+	}
+
+	private clearLoadingDelay() {
+		if (this._loadingDelayTimer) clearTimeout(this._loadingDelayTimer);
+		this._loadingDelayTimer = null;
+	}
+
+	// A full refresh fills both result slots from one full-list query - the page is a slice of it.
+	// Errors propagate to the sync, which keeps the store marked stale and retries until one commits.
+	private async refreshTransactions(token: number) {
+		const userId = this._activeUserId;
 		if (!userId) {
 			this.rawTransactions = [];
 			this.summaryTransactions = [];
@@ -277,88 +303,85 @@ class TradesContext {
 			this.isLoading = false;
 			return;
 		}
-		const refreshId = this._refreshSequence;
 		const pageRefreshId = ++this._pageRefreshSequence;
-		const summaryRefreshId = includeSummary
-			? ++this._summaryRefreshSequence
-			: this._summaryRefreshSequence;
-
-		if (this._loadingDelayTimer) {
-			clearTimeout(this._loadingDelayTimer);
-			this._loadingDelayTimer = null;
-		}
-
-		this._loadingDelayTimer = setTimeout(() => {
-			if (
-				userId !== this._activeUserId ||
-				refreshId !== this._refreshSequence ||
-				pageRefreshId !== this._pageRefreshSequence
-			)
-				return;
-			this.isLoading = true;
-		}, TradesContext.LOADING_DELAY_MS);
+		const summaryRefreshId = ++this._summaryRefreshSequence;
+		this.startLoadingDelay(userId, token, pageRefreshId);
 
 		try {
-			const fields =
-				'id,date,security,type,subtype,description,name,account,quantity,price,amount,fees,expand.account.id,expand.account.name,expand.security.id,expand.security.name,expand.security.symbol,expand.security.currency';
-			const filter = this.activeFilter;
-			if (includeSummary) {
-				const requestedPage = this.page;
-				const summaryList = await this._pb.authedClient
-					.collection('securityTransactions')
-					.getFullList<Trade>({
-						sort: '-date,-created,-id',
-						expand: 'account,security',
-						fields,
-						filter,
-						batch: 200,
-						requestKey: null
-					});
-				if (
-					userId !== this._activeUserId ||
-					refreshId !== this._refreshSequence ||
-					summaryRefreshId !== this._summaryRefreshSequence
-				)
-					return;
-				if (pageRefreshId === this._pageRefreshSequence) {
-					const start = (requestedPage - 1) * this.pageSize;
-					this.rawTransactions = summaryList.slice(start, start + this.pageSize);
-					this.totalItems = summaryList.length;
-				}
-				this.summaryTransactions = summaryList;
+			const requestedPage = this.page;
+			const summaryList = await this._pb.authedClient
+				.collection('securityTransactions')
+				.getFullList<Trade>({
+					sort: '-date,-created,-id',
+					expand: 'account,security',
+					fields: TRADE_FIELDS,
+					filter: this.activeFilter,
+					batch: 200,
+					requestKey: null
+				});
+			if (
+				userId !== this._activeUserId ||
+				!this.sync.isCurrent(token) ||
+				summaryRefreshId !== this._summaryRefreshSequence
+			)
 				return;
+			if (pageRefreshId === this._pageRefreshSequence) {
+				const start = (requestedPage - 1) * this.pageSize;
+				this.rawTransactions = summaryList.slice(start, start + this.pageSize);
+				this.totalItems = summaryList.length;
 			}
-			const pageRequest = this._pb.authedClient
+			this.summaryTransactions = summaryList;
+		} finally {
+			this.clearLoadingDelay();
+			if (
+				userId === this._activeUserId &&
+				this.sync.isCurrent(token) &&
+				pageRefreshId === this._pageRefreshSequence
+			)
+				this.isLoading = false;
+		}
+	}
+
+	// A page change refetches only the page slot: the summary already spans the whole filtered range,
+	// so re-running its full-list query on every page click would be pure waste. Paging is a user
+	// action rather than a sync signal, so it stays outside the staleness ladder.
+	private async refreshPage() {
+		const userId = this._activeUserId;
+		const token = this.sync.current;
+		const pageRefreshId = ++this._pageRefreshSequence;
+		this.startLoadingDelay(userId, token, pageRefreshId);
+
+		try {
+			const pageList = await this._pb.authedClient
 				.collection('securityTransactions')
 				.getList<Trade>(this.page, this.pageSize, {
 					sort: '-date,-created,-id',
 					expand: 'account,security',
-					fields,
-					filter,
+					fields: TRADE_FIELDS,
+					filter: this.activeFilter,
 					requestKey: null
 				});
-			const pageList = await pageRequest;
-			if (userId !== this._activeUserId || refreshId !== this._refreshSequence) return;
-			if (pageRefreshId === this._pageRefreshSequence) {
-				this.rawTransactions = pageList.items;
-				this.totalItems = pageList.totalItems;
-			}
-		} catch (error) {
-			if (userId !== this._activeUserId || refreshId !== this._refreshSequence) return;
 			if (
-				pageRefreshId !== this._pageRefreshSequence &&
-				(!includeSummary || summaryRefreshId !== this._summaryRefreshSequence)
+				userId !== this._activeUserId ||
+				!this.sync.isCurrent(token) ||
+				pageRefreshId !== this._pageRefreshSequence
 			)
 				return;
-			this._pb.handleConnectionError(error, 'securityTransactions', 'refresh');
+			this.rawTransactions = pageList.items;
+			this.totalItems = pageList.totalItems;
+		} catch (error) {
+			if (
+				userId !== this._activeUserId ||
+				!this.sync.isCurrent(token) ||
+				pageRefreshId !== this._pageRefreshSequence
+			)
+				return;
+			this._pb.handleConnectionError(error, 'securityTransactions', 'page');
 		} finally {
-			if (this._loadingDelayTimer) {
-				clearTimeout(this._loadingDelayTimer);
-				this._loadingDelayTimer = null;
-			}
+			this.clearLoadingDelay();
 			if (
 				userId === this._activeUserId &&
-				refreshId === this._refreshSequence &&
+				this.sync.isCurrent(token) &&
 				pageRefreshId === this._pageRefreshSequence
 			)
 				this.isLoading = false;
@@ -370,12 +393,8 @@ class TradesContext {
 			const userId = this._auth.currentUserId;
 			if (userId === this._activeUserId) return;
 			this.unsubscribeRealtime();
-			this._refreshSequence++;
-			this._refreshDebouncer.cancel();
-			if (this._loadingDelayTimer) {
-				clearTimeout(this._loadingDelayTimer);
-				this._loadingDelayTimer = null;
-			}
+			this.sync.cancel();
+			this.clearLoadingDelay();
 			this._activeUserId = userId;
 
 			if (!userId) {
@@ -391,7 +410,7 @@ class TradesContext {
 				if (userId !== this._activeUserId) return;
 				this.realtimeSubscribe(userId);
 				this.syncFromUrl(false);
-				void this.refreshTransactions(userId);
+				void this.sync.refreshNow();
 			});
 		});
 	}
@@ -418,23 +437,12 @@ class TradesContext {
 		this._pb.authedClient.collection('securityTransactions').unsubscribe('*');
 	}
 
+	// A trade event or a realtime reconnect is a pure invalidation signal: it marks the store stale
+	// and schedules the page/summary refetch rather than patching the payload into the cached rows.
 	private onTradeEvent(event: RecordSubscription<Trade>, userId: string) {
 		if (!userId || userId !== this._activeUserId) return;
 		if (!event.action) return;
-		this.invalidate();
-	}
-
-	// A trade event or a realtime reconnect is a pure invalidation signal: it schedules the debounced
-	// page/summary refetch rather than patching the event payload into the cached rows.
-	private invalidate() {
-		const userId = this._activeUserId;
-		if (!userId) return;
-		this._refreshDebouncer.schedule(() => {
-			if (userId !== this._activeUserId) return;
-			this.refreshTransactions(userId).catch((error) =>
-				this._pb.handleConnectionError(error, 'securityTransactions', 'realtime_refresh')
-			);
-		});
+		this.sync.invalidate();
 	}
 
 	private get currentUrl() {
@@ -626,15 +634,15 @@ class TradesContext {
 		const nextPage = Math.min(Math.max(1, page), this.totalPages);
 		if (nextPage === this.page) return;
 		this.page = nextPage;
-		this.refreshTransactions(this._activeUserId, false);
+		void this.refreshPage();
 	}
 
 	dispose() {
 		this._auth.unregisterRealtimeTeardown(this._teardownCallback);
-		this._pb.unregisterRealtimeReconnect(this._reconnectCallback);
+		this._pb.unregisterRealtimeSync(this.sync);
 		if (this._searchDebounceTimer) clearTimeout(this._searchDebounceTimer);
-		if (this._loadingDelayTimer) clearTimeout(this._loadingDelayTimer);
-		this._refreshDebouncer.cancel();
+		this.clearLoadingDelay();
+		this.sync.cancel();
 		this.unsubscribeRealtime();
 	}
 }

--- a/src/lib/transactions.svelte.ts
+++ b/src/lib/transactions.svelte.ts
@@ -17,7 +17,7 @@ import type {
 	TransactionsResponse
 } from './pocketbase.schema';
 import type { PocketBaseContext } from './pocketbase.svelte';
-import { Debouncer } from './realtime-sync';
+import { StaleSync } from './realtime-sync';
 import {
 	createSortComparator,
 	sumPartial,
@@ -26,7 +26,8 @@ import {
 	type SortState
 } from './utils';
 
-const REFRESH_DEBOUNCE_MS = 200;
+const TRANSACTION_FIELDS =
+	'id,date,description,value,excluded,account,labels,expand.account.id,expand.account.name,expand.labels.id,expand.labels.name';
 
 type TransactionSortColumn = 'date' | 'description' | 'account' | 'amount';
 
@@ -98,17 +99,20 @@ class TransactionsContext {
 	private _customLabel: string | null = $state(null);
 	private _searchDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 	private _loadingDelayTimer: ReturnType<typeof setTimeout> | null = null;
-	private _refreshDebouncer = new Debouncer(REFRESH_DEBOUNCE_MS);
+	// Staleness is two-dimensional here: a transaction event can never change the label dictionary,
+	// so the two collections track it separately and a transaction burst never refetches labels.
+	// Both are registered with the realtime registry, so a reconnect marks each of them stale.
+	private sync: StaleSync;
+	private labelsSync: StaleSync;
 	private _activeUserId = '';
 	private _isSubscribed = false;
 	private _teardownCallback = () => this.unsubscribeRealtime();
-	private _reconnectCallback = () => this.invalidate(true);
 	private _unsubscribe: (() => void) | null = null;
 	private _unsubscribeLabels: (() => void) | null = null;
-	private _refreshSequence = 0;
+	// Latest-wins guards for the two result slots a refresh commits into. They are separate because a
+	// page-only refetch must not discard an in-flight full refresh's summary commit.
 	private _pageRefreshSequence = 0;
 	private _summaryRefreshSequence = 0;
-	private _labelRefreshSequence = 0;
 
 	private static readonly LOADING_DELAY_MS = 150;
 	private static readonly SEARCH_DEBOUNCE_MS = 300;
@@ -134,7 +138,14 @@ class TransactionsContext {
 		this._pb = pb;
 		this._auth = getAuthContext();
 		this._auth.registerRealtimeTeardown(this._teardownCallback);
-		this._pb.registerRealtimeReconnect(this._reconnectCallback);
+		this.sync = new StaleSync(pb, 'transactions', 'refresh', (token) =>
+			this.refreshTransactions(token)
+		);
+		this.labelsSync = new StaleSync(pb, 'transactionLabels', 'refresh', (token) =>
+			this.refreshLabels(token)
+		);
+		this._pb.registerRealtimeSync(this.sync);
+		this._pb.registerRealtimeSync(this.labelsSync);
 		this._accountsContext = getAccountsContext();
 		this._fx = getExchangeRatesContext();
 		this.syncFromUrl(false);
@@ -216,7 +227,7 @@ class TransactionsContext {
 
 		if (shouldRefresh) {
 			this.page = 1;
-			this.refreshTransactions();
+			void this.sync.refreshNow();
 		}
 	}
 
@@ -272,12 +283,9 @@ class TransactionsContext {
 			const userId = this._auth.currentUserId;
 			if (userId === this._activeUserId) return;
 			this.unsubscribeRealtime();
-			this._refreshSequence++;
-			this._refreshDebouncer.cancel();
-			if (this._loadingDelayTimer) {
-				clearTimeout(this._loadingDelayTimer);
-				this._loadingDelayTimer = null;
-			}
+			this.sync.cancel();
+			this.labelsSync.cancel();
+			this.clearLoadingDelay();
 			this._activeUserId = userId;
 
 			if (!userId) {
@@ -300,28 +308,23 @@ class TransactionsContext {
 		this.realtimeSubscribe(userId);
 		this.realtimeSubscribeLabels(userId);
 		this.syncFromUrl(false);
-		await this.refreshLabels(userId);
+		await this.labelsSync.refreshNow();
 		if (userId !== this._activeUserId) return;
-		await this.refreshTransactions(userId);
+		await this.sync.refreshNow();
 	}
 
-	private async refreshLabels(userId = this._activeUserId) {
-		if (!userId || userId !== this._activeUserId) return;
+	private async refreshLabels(token: number) {
+		const userId = this._activeUserId;
+		if (!userId) return;
 
-		const labelRefreshId = ++this._labelRefreshSequence;
-		try {
-			const labels = await this._pb.authedClient
-				.collection('transactionLabels')
-				.getFullList<TransactionLabelsResponse>({
-					sort: 'name',
-					requestKey: null
-				});
-			if (userId !== this._activeUserId || labelRefreshId !== this._labelRefreshSequence) return;
-			this.transactionLabels = labels;
-		} catch (error) {
-			if (userId !== this._activeUserId || labelRefreshId !== this._labelRefreshSequence) return;
-			this._pb.handleConnectionError(error, 'transactionLabels', 'refresh');
-		}
+		const labels = await this._pb.authedClient
+			.collection('transactionLabels')
+			.getFullList<TransactionLabelsResponse>({
+				sort: 'name',
+				requestKey: null
+			});
+		if (userId !== this._activeUserId || !this.labelsSync.isCurrent(token)) return;
+		this.transactionLabels = labels;
 	}
 
 	setSearch(query: string) {
@@ -334,7 +337,7 @@ class TransactionsContext {
 		}
 
 		this._searchDebounceTimer = setTimeout(() => {
-			this.refreshTransactions();
+			void this.sync.refreshNow();
 		}, TransactionsContext.SEARCH_DEBOUNCE_MS);
 	}
 
@@ -424,8 +427,42 @@ class TransactionsContext {
 		return this.sortColumn === 'amount' || this.kind === 'credits' || this.kind === 'debits';
 	}
 
-	async refreshTransactions(userId = this._activeUserId, includeSummary = true) {
-		if (userId && userId !== this._activeUserId) return;
+	// The spinner only appears if a refresh is still running after a beat, so a fast refetch doesn't
+	// flash it. The delayed flip is dropped once a newer refresh has taken over.
+	private startLoadingDelay(userId: string, token: number, pageRefreshId: number) {
+		this.clearLoadingDelay();
+		this._loadingDelayTimer = setTimeout(() => {
+			if (
+				userId !== this._activeUserId ||
+				!this.sync.isCurrent(token) ||
+				pageRefreshId !== this._pageRefreshSequence
+			)
+				return;
+			this.isLoading = true;
+		}, TransactionsContext.LOADING_DELAY_MS);
+	}
+
+	private clearLoadingDelay() {
+		if (this._loadingDelayTimer) clearTimeout(this._loadingDelayTimer);
+		this._loadingDelayTimer = null;
+	}
+
+	private fetchPage() {
+		return this._pb.authedClient
+			.collection('transactions')
+			.getList<TransactionsResponse<TransactionExpand>>(this.page, this.pageSize, {
+				sort: this.activeSort,
+				expand: 'account,labels',
+				fields: TRANSACTION_FIELDS,
+				filter: this.activeFilter,
+				requestKey: null
+			});
+	}
+
+	// A full refresh fills both result slots from one round of requests. Errors propagate to the sync,
+	// which keeps the store marked stale and retries until a refresh actually commits.
+	private async refreshTransactions(token: number) {
+		const userId = this._activeUserId;
 		if (!userId) {
 			this.rawTransactions = [];
 			this.summaryTransactions = [];
@@ -433,110 +470,78 @@ class TransactionsContext {
 			this.isLoading = false;
 			return;
 		}
-		const refreshId = this._refreshSequence;
 		const pageRefreshId = ++this._pageRefreshSequence;
-		const summaryRefreshId = includeSummary
-			? ++this._summaryRefreshSequence
-			: this._summaryRefreshSequence;
-
-		if (this._loadingDelayTimer) {
-			clearTimeout(this._loadingDelayTimer);
-			this._loadingDelayTimer = null;
-		}
-
-		this._loadingDelayTimer = setTimeout(() => {
-			if (
-				userId !== this._activeUserId ||
-				refreshId !== this._refreshSequence ||
-				pageRefreshId !== this._pageRefreshSequence
-			)
-				return;
-			this.isLoading = true;
-		}, TransactionsContext.LOADING_DELAY_MS);
+		const summaryRefreshId = ++this._summaryRefreshSequence;
+		this.startLoadingDelay(userId, token, pageRefreshId);
 
 		try {
-			const fields =
-				'id,date,description,value,excluded,account,labels,expand.account.id,expand.account.name,expand.labels.id,expand.labels.name';
-			const filter = this.activeFilter;
-			const sort = this.activeSort;
-			const usesClientPagination = this.usesClientPagination;
-			if (includeSummary) {
-				const summaryRequest = this._pb.authedClient
-					.collection('transactions')
-					.getFullList<TransactionsResponse<TransactionExpand>>({
-						sort,
-						expand: 'account,labels',
-						fields,
-						filter,
-						batch: 200,
-						requestKey: null
-					});
-				if (usesClientPagination) {
-					const summaryList = await summaryRequest;
-					if (
-						userId !== this._activeUserId ||
-						refreshId !== this._refreshSequence ||
-						summaryRefreshId !== this._summaryRefreshSequence
-					)
-						return;
-					this.summaryTransactions = summaryList;
-					return;
-				}
-				const pageRequest = this._pb.authedClient
-					.collection('transactions')
-					.getList<TransactionsResponse<TransactionExpand>>(this.page, this.pageSize, {
-						sort,
-						expand: 'account,labels',
-						fields,
-						filter,
-						requestKey: null
-					});
-				const [pageList, summaryList] = await Promise.all([pageRequest, summaryRequest]);
-				if (
-					userId !== this._activeUserId ||
-					refreshId !== this._refreshSequence ||
-					summaryRefreshId !== this._summaryRefreshSequence
-				)
-					return;
-				if (pageRefreshId === this._pageRefreshSequence) {
-					this.rawTransactions = pageList.items;
-					this.serverTotalItems = pageList.totalItems;
-				}
-				this.summaryTransactions = summaryList;
-				return;
-			}
-			if (usesClientPagination) return;
-			const pageRequest = this._pb.authedClient
+			const summaryRequest = this._pb.authedClient
 				.collection('transactions')
-				.getList<TransactionsResponse<TransactionExpand>>(this.page, this.pageSize, {
-					sort,
+				.getFullList<TransactionsResponse<TransactionExpand>>({
+					sort: this.activeSort,
 					expand: 'account,labels',
-					fields,
-					filter,
+					fields: TRANSACTION_FIELDS,
+					filter: this.activeFilter,
+					batch: 200,
 					requestKey: null
 				});
-			const pageList = await pageRequest;
-			if (userId !== this._activeUserId || refreshId !== this._refreshSequence) return;
-			if (pageRefreshId === this._pageRefreshSequence) {
+			// Client-paginated views slice the summary in memory, so there is no page request to make.
+			const pageRequest = this.usesClientPagination ? null : this.fetchPage();
+			const [pageList, summaryList] = await Promise.all([pageRequest, summaryRequest]);
+			if (
+				userId !== this._activeUserId ||
+				!this.sync.isCurrent(token) ||
+				summaryRefreshId !== this._summaryRefreshSequence
+			)
+				return;
+			if (pageList && pageRefreshId === this._pageRefreshSequence) {
 				this.rawTransactions = pageList.items;
 				this.serverTotalItems = pageList.totalItems;
 			}
-		} catch (error) {
-			if (userId !== this._activeUserId || refreshId !== this._refreshSequence) return;
-			if (
-				pageRefreshId !== this._pageRefreshSequence &&
-				(!includeSummary || summaryRefreshId !== this._summaryRefreshSequence)
-			)
-				return;
-			this._pb.handleConnectionError(error, 'transactions', 'refresh');
+			this.summaryTransactions = summaryList;
 		} finally {
-			if (this._loadingDelayTimer) {
-				clearTimeout(this._loadingDelayTimer);
-				this._loadingDelayTimer = null;
-			}
+			this.clearLoadingDelay();
 			if (
 				userId === this._activeUserId &&
-				refreshId === this._refreshSequence &&
+				this.sync.isCurrent(token) &&
+				pageRefreshId === this._pageRefreshSequence
+			)
+				this.isLoading = false;
+		}
+	}
+
+	// A server-paginated page change refetches only the page slot: the summary already spans the whole
+	// filtered range, so re-running its full-list query on every page click would be pure waste. Paging
+	// is a user action rather than a sync signal, so it stays outside the staleness ladder.
+	private async refreshPage() {
+		const userId = this._activeUserId;
+		const token = this.sync.current;
+		const pageRefreshId = ++this._pageRefreshSequence;
+		this.startLoadingDelay(userId, token, pageRefreshId);
+
+		try {
+			const pageList = await this.fetchPage();
+			if (
+				userId !== this._activeUserId ||
+				!this.sync.isCurrent(token) ||
+				pageRefreshId !== this._pageRefreshSequence
+			)
+				return;
+			this.rawTransactions = pageList.items;
+			this.serverTotalItems = pageList.totalItems;
+		} catch (error) {
+			if (
+				userId !== this._activeUserId ||
+				!this.sync.isCurrent(token) ||
+				pageRefreshId !== this._pageRefreshSequence
+			)
+				return;
+			this._pb.handleConnectionError(error, 'transactions', 'page');
+		} finally {
+			this.clearLoadingDelay();
+			if (
+				userId === this._activeUserId &&
+				this.sync.isCurrent(token) &&
 				pageRefreshId === this._pageRefreshSequence
 			)
 				this.isLoading = false;
@@ -573,7 +578,7 @@ class TransactionsContext {
 
 		this._pb.authedClient
 			.collection('transactionLabels')
-			.subscribe('*', () => this.refreshLabels(userId))
+			.subscribe('*', () => this.labelsSync.invalidate())
 			.then((unsubscribe) => {
 				if (userId !== this._activeUserId) {
 					unsubscribe();
@@ -599,29 +604,16 @@ class TransactionsContext {
 		this._unsubscribeLabels = null;
 	}
 
+	// A transaction event is a pure invalidation signal: it marks the store stale and schedules the
+	// page/summary refetch rather than patching the event payload. It never touches the label
+	// dictionary, which no transaction mutation can change - a reconnect covers that separately.
 	private onTransactionEvent(
 		e: RecordSubscription<TransactionsResponse<TransactionExpand>>,
 		userId: string
 	) {
 		if (!userId || userId !== this._activeUserId) return;
 		if (!e.action) return;
-		this.invalidate(false);
-	}
-
-	// A transaction event or a realtime reconnect is a pure invalidation signal: it schedules the
-	// debounced page/summary refetch rather than patching the event payload. A reconnect may also
-	// have missed transactionLabels events, so it refreshes labels too; a plain transaction event
-	// cannot change labels and skips them.
-	private invalidate(includeLabels: boolean) {
-		const userId = this._activeUserId;
-		if (!userId) return;
-		this._refreshDebouncer.schedule(() => {
-			if (userId !== this._activeUserId) return;
-			if (includeLabels) void this.refreshLabels(userId);
-			this.refreshTransactions(userId).catch((error) =>
-				this._pb.handleConnectionError(error, 'transactions', 'realtime_refresh')
-			);
-		});
+		this.sync.invalidate();
 	}
 
 	private getPeriodRange(option: PeriodOption) {
@@ -860,7 +852,7 @@ class TransactionsContext {
 
 		this.updateUrl(params);
 		this.page = 1;
-		this.refreshTransactions();
+		void this.sync.refreshNow();
 	}
 
 	setPresetPeriod(option: PeriodOption) {
@@ -879,7 +871,7 @@ class TransactionsContext {
 
 		this.updateUrl(params);
 		this.page = 1;
-		this.refreshTransactions();
+		void this.sync.refreshNow();
 	}
 
 	setKind(option: KindFilter) {
@@ -890,7 +882,7 @@ class TransactionsContext {
 		this.syncFiltersToParams(params);
 
 		this.updateUrl(params);
-		this.refreshTransactions();
+		void this.sync.refreshNow();
 	}
 
 	setAccountFilter(accountId: string | null) {
@@ -901,7 +893,7 @@ class TransactionsContext {
 		this.syncFiltersToParams(params);
 
 		this.updateUrl(params);
-		this.refreshTransactions();
+		void this.sync.refreshNow();
 	}
 
 	private applyLabelFilters(labelIds: string[]) {
@@ -912,7 +904,7 @@ class TransactionsContext {
 		this.syncFiltersToParams(params);
 
 		this.updateUrl(params);
-		this.refreshTransactions();
+		void this.sync.refreshNow();
 	}
 
 	toggleLabelFilter(labelId: string) {
@@ -951,7 +943,7 @@ class TransactionsContext {
 		params.set('dir', this.sortDirection);
 
 		this.updateUrl(params);
-		this.refreshTransactions();
+		void this.sync.refreshNow();
 	}
 
 	setPage(page: number) {
@@ -959,7 +951,7 @@ class TransactionsContext {
 		if (nextPage === this.page) return;
 		this.page = nextPage;
 		if (this.usesClientPagination) return;
-		this.refreshTransactions(this._activeUserId, false);
+		void this.refreshPage();
 	}
 
 	get selectedIds() {
@@ -1026,10 +1018,12 @@ class TransactionsContext {
 
 	dispose() {
 		this._auth.unregisterRealtimeTeardown(this._teardownCallback);
-		this._pb.unregisterRealtimeReconnect(this._reconnectCallback);
+		this._pb.unregisterRealtimeSync(this.sync);
+		this._pb.unregisterRealtimeSync(this.labelsSync);
 		if (this._searchDebounceTimer) clearTimeout(this._searchDebounceTimer);
-		if (this._loadingDelayTimer) clearTimeout(this._loadingDelayTimer);
-		this._refreshDebouncer.cancel();
+		this.clearLoadingDelay();
+		this.sync.cancel();
+		this.labelsSync.cancel();
 		this.unsubscribeRealtime();
 	}
 }

--- a/src/routes/(app)/trends/+page.svelte
+++ b/src/routes/(app)/trends/+page.svelte
@@ -27,7 +27,7 @@
 		SecurityBalancesResponse
 	} from '$lib/pocketbase.schema';
 	import { getPocketBaseContext } from '$lib/pocketbase.svelte';
-	import { Debouncer, RequestSequence } from '$lib/realtime-sync';
+	import { StaleSync } from '$lib/realtime-sync';
 	import { getSecuritiesContext } from '$lib/securities.svelte';
 	import { projectSignedValue } from '$lib/sharing';
 	import { toNumber } from '$lib/utils';
@@ -243,189 +243,179 @@
 		});
 	}
 
-	const sequence = new RequestSequence();
-	const debouncer = new Debouncer(200);
+	const sync = new StaleSync(pb, 'trends', 'refresh_balances', (token) => refresh(token));
 	let disposed = false;
 	let lastIncludedSignature = '';
 
-	async function refresh() {
-		if (disposed) return;
-		const token = sequence.next();
-		try {
-			const start = computeBoundedHistoryStart('5y');
-			if (!start) return;
-			// Snapshot the signature this refresh reflects; the signature effect treats any later
-			// divergence - including one committed while this refresh is in flight - as a change.
-			lastIncludedSignature = includedSignature;
-			const accountIds = Array.from(includedAccounts.keys());
-			const assetIds = Array.from(includedAssets.keys());
-			const accountFilter = filterByIds('account', accountIds);
-			const assetFilter = filterByIds('asset', assetIds);
-			const accountHistoryFilter = historyFilter(accountFilter, start);
-			const assetHistoryFilter = historyFilter(assetFilter, start);
-			try {
-				const [
-					accountBalancesRange,
-					securityBalancesRangeRaw,
-					assetBalancesRange,
-					accountBalancesFullHistory,
-					securityBalancesFullHistoryRaw,
-					assetBalancesFullHistory
-				] = await Promise.all([
-					listAccountBalances(accountHistoryFilter),
-					listSecurityBalances(accountHistoryFilter),
-					listAssetBalances(assetHistoryFilter),
-					listAccountBalances(accountFilter),
-					listSecurityBalances(accountFilter),
-					listAssetBalances(assetFilter)
-				]);
+	async function refresh(token: number) {
+		const start = computeBoundedHistoryStart('5y');
+		if (!start) return;
+		// Claim the signature this refresh reads before issuing it, so the signature effect treats the
+		// set as already covered instead of scheduling a duplicate refresh on top of the bootstrap one.
+		// A refresh that fails does not have to give the claim back: the sync keeps the page stale and
+		// its retry re-reads `includedSignature`, so recovery never depends on this value.
+		lastIncludedSignature = includedSignature;
+		const accountIds = Array.from(includedAccounts.keys());
+		const assetIds = Array.from(includedAssets.keys());
+		const accountFilter = filterByIds('account', accountIds);
+		const assetFilter = filterByIds('asset', assetIds);
+		const accountHistoryFilter = historyFilter(accountFilter, start);
+		const assetHistoryFilter = historyFilter(assetFilter, start);
+		const [
+			accountBalancesRange,
+			securityBalancesRangeRaw,
+			assetBalancesRange,
+			accountBalancesFullHistory,
+			securityBalancesFullHistoryRaw,
+			assetBalancesFullHistory
+		] = await Promise.all([
+			listAccountBalances(accountHistoryFilter),
+			listSecurityBalances(accountHistoryFilter),
+			listAssetBalances(assetHistoryFilter),
+			listAccountBalances(accountFilter),
+			listSecurityBalances(accountFilter),
+			listAssetBalances(assetFilter)
+		]);
 
-				const securityBalancesRange = securityBalancesRangeRaw
-					.map(projectSecurityBalance)
-					.filter(isDefined);
-				const securityBalancesFullHistory = securityBalancesFullHistoryRaw
-					.map(projectSecurityBalance)
-					.filter(isDefined);
-				const [accountBalancesPrevious, securityBalancesPrevious, assetBalancesPrevious] =
-					await Promise.all([
-						Promise.all(
-							accountIds.map(async (accountId) => {
-								const result = await pb.authedClient
-									.collection('accountBalances')
-									.getList<AccountBalancesResponse>(1, 1, {
-										filter: `account='${quoteFilterValue(accountId)}' && asOf<'${start.toISOString()}'`,
-										sort: '-asOf,-created,-id',
-										fields: 'id,account,value,asOf,created',
-										requestKey: null
-									});
-								return result.items[0] ?? null;
-							})
-						),
-						(async () => {
-							if (!accountFilter) return [];
-							const balances = await pb.authedClient
-								.collection('securityBalances')
-								.getFullList<SecurityBalancesResponse<number, number, number, number>>({
-									filter: `(${accountFilter}) && asOf<'${start.toISOString()}'`,
-									sort: 'account,security,asOf,created,id',
-									fields: 'id,account,security,value,quantity,asOf,created',
-									requestKey: null
-								});
+		const securityBalancesRange = securityBalancesRangeRaw
+			.map(projectSecurityBalance)
+			.filter(isDefined);
+		const securityBalancesFullHistory = securityBalancesFullHistoryRaw
+			.map(projectSecurityBalance)
+			.filter(isDefined);
+		const [accountBalancesPrevious, securityBalancesPrevious, assetBalancesPrevious] =
+			await Promise.all([
+				Promise.all(
+					accountIds.map(async (accountId) => {
+						const result = await pb.authedClient
+							.collection('accountBalances')
+							.getList<AccountBalancesResponse>(1, 1, {
+								filter: `account='${quoteFilterValue(accountId)}' && asOf<'${start.toISOString()}'`,
+								sort: '-asOf,-created,-id',
+								fields: 'id,account,value,asOf,created',
+								requestKey: null
+							});
+						return result.items[0] ?? null;
+					})
+				),
+				(async () => {
+					if (!accountFilter) return [];
+					const balances = await pb.authedClient
+						.collection('securityBalances')
+						.getFullList<SecurityBalancesResponse<number, number, number, number>>({
+							filter: `(${accountFilter}) && asOf<'${start.toISOString()}'`,
+							sort: 'account,security,asOf,created,id',
+							fields: 'id,account,security,value,quantity,asOf,created',
+							requestKey: null
+						});
 
-							const latestByKey = new SvelteMap<
-								string,
-								{
-									balance: SecurityBalancesResponse<number, number, number, number>;
-									lastKnownValue: number | null;
-									soldOut: boolean;
-								}
-							>();
-							for (const balance of balances) {
-								const key = `${balance.account}:${balance.security}`;
-								const existing = latestByKey.get(key) ?? {
-									balance,
-									lastKnownValue: null,
-									soldOut: false
-								};
-								if (toNumber(balance.quantity) === 0) {
-									existing.lastKnownValue = 0;
-									existing.soldOut = true;
-								} else {
-									const value = toNumber(balance.value);
-									if (value !== null) {
-										existing.lastKnownValue = value;
-										existing.soldOut = false;
-									}
-								}
-								existing.balance = balance;
-								latestByKey.set(key, existing);
+					const latestByKey = new SvelteMap<
+						string,
+						{
+							balance: SecurityBalancesResponse<number, number, number, number>;
+							lastKnownValue: number | null;
+							soldOut: boolean;
+						}
+					>();
+					for (const balance of balances) {
+						const key = `${balance.account}:${balance.security}`;
+						const existing = latestByKey.get(key) ?? {
+							balance,
+							lastKnownValue: null,
+							soldOut: false
+						};
+						if (toNumber(balance.quantity) === 0) {
+							existing.lastKnownValue = 0;
+							existing.soldOut = true;
+						} else {
+							const value = toNumber(balance.value);
+							if (value !== null) {
+								existing.lastKnownValue = value;
+								existing.soldOut = false;
 							}
-							return Array.from(latestByKey.values()).map(
-								({ balance, lastKnownValue, soldOut }) => ({
-									...balance,
-									value: soldOut ? balance.value : lastKnownValue
-								})
-							);
-						})(),
-						Promise.all(
-							assetIds.map(async (assetId) => {
-								const result = await pb.authedClient
-									.collection('assetBalances')
-									.getList<AssetBalancesResponse>(1, 1, {
-										filter: `asset='${quoteFilterValue(assetId)}' && asOf<'${start.toISOString()}'`,
-										sort: '-asOf,-created,-id',
-										fields: 'id,asset,marketValue,asOf,created',
-										requestKey: null
-									});
-								return result.items[0] ?? null;
-							})
-						)
-					]);
+						}
+						existing.balance = balance;
+						latestByKey.set(key, existing);
+					}
+					return Array.from(latestByKey.values()).map(({ balance, lastKnownValue, soldOut }) => ({
+						...balance,
+						value: soldOut ? balance.value : lastKnownValue
+					}));
+				})(),
+				Promise.all(
+					assetIds.map(async (assetId) => {
+						const result = await pb.authedClient
+							.collection('assetBalances')
+							.getList<AssetBalancesResponse>(1, 1, {
+								filter: `asset='${quoteFilterValue(assetId)}' && asOf<'${start.toISOString()}'`,
+								sort: '-asOf,-created,-id',
+								fields: 'id,asset,marketValue,asOf,created',
+								requestKey: null
+							});
+						return result.items[0] ?? null;
+					})
+				)
+			]);
 
-				if (disposed || !sequence.isCurrent(token)) return;
+		if (disposed || !sync.isCurrent(token)) return;
 
-				const accountBalances = trimBalances(
-					[...accountBalancesPrevious, ...accountBalancesRange]
-						.map((balance) => (balance ? projectAccountBalance(balance) : null))
-						.filter(isDefined),
-					start,
-					(balance) => balance.account
-				);
-				const securityBalances = trimBalances(
-					[
-						...securityBalancesPrevious
-							.map((balance) => (balance ? projectSecurityBalance(balance) : null))
-							.filter(isDefined),
-						...securityBalancesRange
-					],
-					start,
-					(balance) => `${balance.account}:${balance.security}`
-				);
-				const assetBalances = trimBalances(
-					[...assetBalancesPrevious, ...assetBalancesRange]
-						.map((balance) => (balance ? projectAssetBalance(balance) : null))
-						.filter(isDefined),
-					start,
-					(balance) => balance.asset
-				);
-				rawAccounts = Array.from(includedAccounts.values());
-				rawAssets = Array.from(includedAssets.values());
-				rawAccountBalances = accountBalances;
-				rawSecurityBalances = securityBalances;
-				rawAssetBalances = assetBalances;
-				rawFullHistoryAccountBalances = trimBalances(
-					accountBalancesFullHistory.map(projectAccountBalance).filter(isDefined),
-					null,
-					(balance) => balance.account
-				);
-				rawFullHistorySecurityBalances = trimBalances(
-					securityBalancesFullHistory,
-					null,
-					(balance) => `${balance.account}:${balance.security}`
-				);
-				rawFullHistoryAssetBalances = trimBalances(
-					assetBalancesFullHistory.map(projectAssetBalance).filter(isDefined),
-					null,
-					(balance) => balance.asset
-				);
-			} catch (error) {
-				if (!disposed && sequence.isCurrent(token))
-					pb.handleConnectionError(error, 'trends', 'refresh_balances');
-			}
-		} finally {
-			if (!disposed && sequence.isCurrent(token)) bootstrapped = true;
-		}
+		const accountBalances = trimBalances(
+			[...accountBalancesPrevious, ...accountBalancesRange]
+				.map((balance) => (balance ? projectAccountBalance(balance) : null))
+				.filter(isDefined),
+			start,
+			(balance) => balance.account
+		);
+		const securityBalances = trimBalances(
+			[
+				...securityBalancesPrevious
+					.map((balance) => (balance ? projectSecurityBalance(balance) : null))
+					.filter(isDefined),
+				...securityBalancesRange
+			],
+			start,
+			(balance) => `${balance.account}:${balance.security}`
+		);
+		const assetBalances = trimBalances(
+			[...assetBalancesPrevious, ...assetBalancesRange]
+				.map((balance) => (balance ? projectAssetBalance(balance) : null))
+				.filter(isDefined),
+			start,
+			(balance) => balance.asset
+		);
+		rawAccounts = Array.from(includedAccounts.values());
+		rawAssets = Array.from(includedAssets.values());
+		rawAccountBalances = accountBalances;
+		rawSecurityBalances = securityBalances;
+		rawAssetBalances = assetBalances;
+		rawFullHistoryAccountBalances = trimBalances(
+			accountBalancesFullHistory.map(projectAccountBalance).filter(isDefined),
+			null,
+			(balance) => balance.account
+		);
+		rawFullHistorySecurityBalances = trimBalances(
+			securityBalancesFullHistory,
+			null,
+			(balance) => `${balance.account}:${balance.security}`
+		);
+		rawFullHistoryAssetBalances = trimBalances(
+			assetBalancesFullHistory.map(projectAssetBalance).filter(isDefined),
+			null,
+			(balance) => balance.asset
+		);
+		// Only a committed refresh clears the loading state: a failed bootstrap must not render empty
+		// charts as if they were the answer while the sync is still retrying.
+		bootstrapped = true;
 	}
 
 	function invalidate() {
 		if (disposed) return;
-		sequence.bump();
-		debouncer.schedule(() => void refresh());
+		sync.invalidate();
 	}
 
 	$effect(() => {
 		const unsubscribes: Array<() => void> = [];
-		pb.registerRealtimeReconnect(invalidate);
+		pb.registerRealtimeSync(sync);
 		function addSubscription(subscription: Promise<() => void>) {
 			subscription
 				.then((unsubscribe) => {
@@ -447,9 +437,8 @@
 
 		return () => {
 			disposed = true;
-			sequence.bump();
-			debouncer.cancel();
-			pb.unregisterRealtimeReconnect(invalidate);
+			sync.cancel();
+			pb.unregisterRealtimeSync(sync);
 			for (const unsubscribe of unsubscribes) unsubscribe();
 		};
 	});
@@ -461,14 +450,14 @@
 		if (bootstrapped) return;
 		if (accountsCtx?.isLoading || assetsCtx?.isLoading) return;
 		untrack(() => {
-			void refresh();
+			void sync.refreshNow();
 		});
 	});
 
 	$effect(() => {
 		const signature = includedSignature;
 		if (signature === lastIncludedSignature) return;
-		const refreshStarted = sequence.current > 0;
+		const refreshStarted = sync.current > 0;
 		lastIncludedSignature = signature;
 		if (!bootstrapped && !refreshStarted) return;
 		invalidate();


### PR DESCRIPTION
- A failed or cancelled store refetch was silently discarded, so a transient error during reconnect recovery left stale finance data until an unrelated event happened to invalidate the store again, which for a quiet collection could be never.
- Staleness is now durable per store: a new `StaleSync` primitive owns the stale flag, the debounce, and a retry ladder (1s doubling to a 30s cap, paused while the tab is hidden, reset by online/visibility/fresh events), and the flag only clears when a refetch actually commits.
- The reconnect recovery registry shrinks to marking stores stale on disconnect, poking retries on reconnect signals, and one shared health probe that keeps offline retries down to a single cheap request; the probe ladder and the trigger-coalescing latches (including #440's `_pendingRecovery`) are gone because an idempotent flag cannot drop a signal.
- Two adjacent bugs fixed along the way: a refresh already in flight when the socket dropped could clear the stale mark it should have honored, and the trends page latched `bootstrapped` even when its bootstrap fetch failed, showing empty charts until navigation.
- Net −37 lines across 15 files, and reconnect recovery converges noticeably faster without the bounded probe ladder; the flaky shared-records reconnect test passed 38 consecutive runs at CI concurrency (a ~1-in-350 WebKit-only failure under full-suite saturation remains, reproduced identically on unmodified master, and is a test-harness socket-gating issue rather than store behavior).

Closes #443